### PR TITLE
Feature/auth role validation

### DIFF
--- a/src/common/database/seeds/superadmin-seeding/seeding.service.ts
+++ b/src/common/database/seeds/superadmin-seeding/seeding.service.ts
@@ -38,7 +38,7 @@ export class SeedingService {
         throw new Error('JWT secret is not defined');
       }
 
-      const superAdminToken: string = jwt.sign({ isLogginToken: true }, secret, {
+      const superAdminToken: string = jwt.sign({ isLogginToken: true, role: Roles.SUPERADMIN }, secret, {
         expiresIn: '1h',
       });
 
@@ -46,7 +46,7 @@ export class SeedingService {
         from: { name: 'codecrafters', address: 'codecrafters@mail.com' },
         recipients: [{ name: superAdmin.full_name, address: superAdmin.email }],
         subject: 'invitation link',
-        html: `<a href="http://application-api?inviteToken=${superAdminToken}">invitation link</a>`,
+        html: `<a href="http://localhost:5473?inviteToken=${superAdminToken}">invitation link</a>`,
         placeholderReplacements: {},
       };
 

--- a/src/common/database/seeds/superadmin-seeding/seeding.service.ts
+++ b/src/common/database/seeds/superadmin-seeding/seeding.service.ts
@@ -46,7 +46,7 @@ export class SeedingService {
         from: { name: 'codecrafters', address: 'codecrafters@mail.com' },
         recipients: [{ name: superAdmin.full_name, address: superAdmin.email }],
         subject: 'invitation link',
-        html: `<a href="http://localhost:5473?inviteToken=${superAdminToken}">invitation link</a>`,
+        html: `<a href="${this.configService.getOrThrow('FE_LINK')}?inviteToken=${superAdminToken}">invitation link</a>`,
         placeholderReplacements: {},
       };
 

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { BadRequestException, Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { isEmail } from 'class-validator';
 import { InvitationTokenGuard } from 'common/guards/InvitationTokenGuard.guard';
@@ -18,9 +18,9 @@ export class AuthController {
   @ApiResponse({ status: 200, type: AuthResponseDto })
   @ApiResponse({ status: 400, type: BadRequestResponseDto })
   @UseGuards(InvitationTokenGuard)
-  async findOne(@Param('email') email: string): Promise<{ token: string } | BadRequestException> {
+  async findOne(@Param('email') email: string, @Query() invitationToken: string): Promise<{ token: string } | BadRequestException> {
     if (isEmail(email)) {
-      return this.authService.authByEmail(email);
+      return this.authService.authByEmail(email, invitationToken);
     }
 
     throw new BadRequestException("String isn't email");

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -18,7 +18,10 @@ export class AuthController {
   @ApiResponse({ status: 200, type: AuthResponseDto })
   @ApiResponse({ status: 400, type: BadRequestResponseDto })
   @UseGuards(InvitationTokenGuard)
-  async findOne(@Param('email') email: string, @Query() invitationToken: string): Promise<{ token: string } | BadRequestException> {
+  async findOne(
+    @Param('email') email: string,
+    @Query() { invitationToken }: { invitationToken: string },
+  ): Promise<{ token: string } | BadRequestException> {
     if (isEmail(email)) {
       return this.authService.authByEmail(email, invitationToken);
     }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -2,8 +2,13 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from 'common/database/entities/user.entity';
+import { Roles } from 'common/enums/enums';
 import * as jwt from 'jsonwebtoken';
 import { Repository } from 'typeorm';
+
+interface InviteTokenPayload extends jwt.Jwt {
+  role: Roles;
+}
 
 @Injectable()
 export class AuthService {
@@ -13,9 +18,13 @@ export class AuthService {
     private readonly configService: ConfigService,
   ) {}
 
-  async authByEmail(email: string): Promise<{ token: string } | BadRequestException> {
+  async authByEmail(email: string, invitationToken: string): Promise<{ token: string } | BadRequestException> {
     try {
       const user: User = await this.userRepo.findOneOrFail({ where: { email } });
+
+      const decodedToken = <InviteTokenPayload>jwt.decode(invitationToken, this.configService.getOrThrow('JWT_SECRET'));
+
+      if (decodedToken.role !== user.role) throw new Error();
 
       const secret: string = this.configService.getOrThrow('JWT_SECRET');
       const token: string = jwt.sign({ fullName: user.full_name, email: user.email, role: user.role }, secret, { expiresIn: '12h' });

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -22,7 +22,7 @@ export class AuthService {
     try {
       const user: User = await this.userRepo.findOneOrFail({ where: { email } });
 
-      const decodedToken = <InviteTokenPayload>jwt.decode(invitationToken, this.configService.getOrThrow('JWT_SECRET'));
+      const decodedToken = <InviteTokenPayload>jwt.decode(invitationToken);
 
       if (decodedToken.role !== user.role) throw new Error();
 


### PR DESCRIPTION
## Describe your changes

- Validate user role before auth. When logging in, a user could previously access the super admin account if they knew the super admin's email. This option is no longer available now

## Example
![users](https://github.com/user-attachments/assets/8b0a8871-91fb-40db-b2a7-ca8d0162105f)

superadmin auth with admin email
![auth-with-another-role-email](https://github.com/user-attachments/assets/d1d1a8f7-f679-40ad-9730-ffbd49772ce7)

superadmin auth with superadmin email
![auth-with-correct-role](https://github.com/user-attachments/assets/d19e64c6-cefe-4cb9-9565-54a2bb407c0e)


### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [x] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [x] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
