### PR TITLE
+ Create: CRUD logic

### DIFF
--- a/src/modules/user/driver/driver.controller.ts
+++ b/src/modules/user/driver/driver.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, SetMetadata, Headers } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, SetMetadata } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { User } from 'common/database/entities/user.entity';
 import { Roles } from 'common/enums/enums';
 import { RolesGuard } from 'common/guards/roles.guard';
+import { UserCompanyGuard } from 'common/guards/userCompany.guard';
 import { ResponseInterface } from 'common/types/interfaces';
 
 import { DriverService } from './driver.service';
@@ -14,40 +15,36 @@ export class DriverController {
   constructor(private readonly driverService: DriverService) {}
 
   @Post()
-  @UseGuards(RolesGuard)
+  @UseGuards(RolesGuard, UserCompanyGuard)
   @SetMetadata('roles', [Roles.ADMIN, Roles.DISPATCHER])
   @ApiOperation({ summary: 'Create driver' })
   @ApiResponse({ status: 201, type: User })
-  async create(@Body() createDriverDto: CreateDriverDto, @Headers() { authorization }: { authorization: string }): Promise<User> {
-    return this.driverService.create(createDriverDto, authorization);
+  async create(@Body() createDriverDto: CreateDriverDto): Promise<User> {
+    return this.driverService.create(createDriverDto);
   }
 
   @Get(':id')
-  @UseGuards(RolesGuard)
+  @UseGuards(RolesGuard, UserCompanyGuard)
   @SetMetadata('roles', [Roles.ADMIN, Roles.DISPATCHER])
   @ApiOperation({ summary: 'Get driver' })
   @ApiResponse({ status: 200, type: User })
-  async findOne(@Param('id') id: string, @Headers() { authorization }: { authorization: string }): Promise<User> {
-    return this.driverService.findOne(+id, authorization);
+  async findOne(@Param('id') id: string): Promise<User> {
+    return this.driverService.findOne(+id);
   }
 
   @Patch(':id')
-  @UseGuards(RolesGuard)
+  @UseGuards(RolesGuard, UserCompanyGuard)
   @SetMetadata('roles', [Roles.ADMIN, Roles.DISPATCHER])
   @ApiOperation({ summary: 'Update driver' })
-  async update(
-    @Param('id') id: string,
-    @Body() updateDriverDto: UpdateDriverDto,
-    @Headers() { authorization }: { authorization: string },
-  ): Promise<ResponseInterface> {
-    return this.driverService.update(+id, updateDriverDto, authorization);
+  async update(@Param('id') id: string, @Body() updateDriverDto: UpdateDriverDto): Promise<ResponseInterface> {
+    return this.driverService.update(+id, updateDriverDto);
   }
 
   @Delete(':id')
-  @UseGuards(RolesGuard)
+  @UseGuards(RolesGuard, UserCompanyGuard)
   @SetMetadata('roles', [Roles.ADMIN, Roles.DISPATCHER])
   @ApiOperation({ summary: 'Delete driver' })
-  async remove(@Param('id') id: string, @Headers() { authorization }: { authorization: string }): Promise<ResponseInterface> {
-    return this.driverService.remove(+id, authorization);
+  async remove(@Param('id') id: string): Promise<ResponseInterface> {
+    return this.driverService.remove(+id);
   }
 }

--- a/src/modules/user/driver/driver.controller.ts
+++ b/src/modules/user/driver/driver.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, SetMetadata, Headers } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { User } from 'common/database/entities/user.entity';
+import { Roles } from 'common/enums/enums';
+import { RolesGuard } from 'common/guards/roles.guard';
+import { ResponseInterface } from 'common/types/interfaces';
+
+import { DriverService } from './driver.service';
+import { CreateDriverDto } from './dto/create-driver.dto';
+import { UpdateDriverDto } from './dto/update-driver.dto';
+
+@Controller('driver')
+export class DriverController {
+  constructor(private readonly driverService: DriverService) {}
+
+  @Post()
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.ADMIN, Roles.DISPATCHER])
+  @ApiOperation({ summary: 'Create driver' })
+  @ApiResponse({ status: 201, type: User })
+  async create(@Body() createDriverDto: CreateDriverDto, @Headers() { authorization }: { authorization: string }): Promise<User> {
+    return this.driverService.create(createDriverDto, authorization);
+  }
+
+  @Get(':id')
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.ADMIN, Roles.DISPATCHER])
+  @ApiOperation({ summary: 'Get driver' })
+  @ApiResponse({ status: 200, type: User })
+  async findOne(@Param('id') id: string, @Headers() { authorization }: { authorization: string }): Promise<User> {
+    return this.driverService.findOne(+id, authorization);
+  }
+
+  @Patch(':id')
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.ADMIN, Roles.DISPATCHER])
+  @ApiOperation({ summary: 'Update driver' })
+  async update(
+    @Param('id') id: string,
+    @Body() updateDriverDto: UpdateDriverDto,
+    @Headers() { authorization }: { authorization: string },
+  ): Promise<ResponseInterface> {
+    return this.driverService.update(+id, updateDriverDto, authorization);
+  }
+
+  @Delete(':id')
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.ADMIN, Roles.DISPATCHER])
+  @ApiOperation({ summary: 'Delete driver' })
+  async remove(@Param('id') id: string, @Headers() { authorization }: { authorization: string }): Promise<ResponseInterface> {
+    return this.driverService.remove(+id, authorization);
+  }
+}

--- a/src/modules/user/driver/driver.module.ts
+++ b/src/modules/user/driver/driver.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Company } from 'common/database/entities/company.entity';
+import { User } from 'common/database/entities/user.entity';
+
+import { DriverController } from './driver.controller';
+import { DriverService } from './driver.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User, Company])],
+  controllers: [DriverController],
+  providers: [DriverService],
+})
+export class DriverModule {}

--- a/src/modules/user/driver/driver.service.ts
+++ b/src/modules/user/driver/driver.service.ts
@@ -1,0 +1,83 @@
+import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Company } from 'common/database/entities/company.entity';
+import { User } from 'common/database/entities/user.entity';
+import { Roles } from 'common/enums/enums';
+import { ResponseInterface } from 'common/types/interfaces';
+import * as jwt from 'jsonwebtoken';
+import { EntityManager, Repository } from 'typeorm';
+
+import { CreateDriverDto } from './dto/create-driver.dto';
+import { UpdateDriverDto } from './dto/update-driver.dto';
+
+interface AccessTokenInterface extends jwt.Jwt {
+  fullName: string;
+  email: string;
+  role: Roles;
+  company_id: Company;
+}
+
+@Injectable()
+export class DriverService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    @InjectRepository(Company)
+    private readonly companyRepo: Repository<Company>,
+    private readonly entityManager: EntityManager,
+  ) {}
+
+  async create(createDriverDto: CreateDriverDto, authorization: string): Promise<User> {
+    try {
+      const company = await this.companyRepo.findOneByOrFail({ id: createDriverDto.company_id });
+
+      const decodedToken = <AccessTokenInterface>jwt.decode(authorization);
+      if (company.id !== decodedToken.company_id.id) throw new BadRequestException("You doesn't work in this company");
+
+      const dispatcher = this.userRepo.create({ ...createDriverDto, company_id: company });
+      return await this.entityManager.save(dispatcher);
+    } catch (error) {
+      throw new InternalServerErrorException('Internal server error');
+    }
+  }
+
+  async findOne(id: number, authorization: string): Promise<User> {
+    try {
+      const dispatcher = await this.userRepo.findOneByOrFail({ id });
+
+      const decodedToken = <AccessTokenInterface>jwt.decode(authorization);
+      if (dispatcher.company_id.id !== decodedToken.company_id.id) throw new BadRequestException("You doesn't work in this company");
+      return await this.userRepo.findOneByOrFail({ id });
+    } catch (error) {
+      throw new BadRequestException('There is no such dispatcher');
+    }
+  }
+
+  async update(id: number, updateDriverDto: UpdateDriverDto, authorization: string): Promise<ResponseInterface> {
+    try {
+      const dispatcher = await this.userRepo.findOneByOrFail({ id });
+
+      const decodedToken = <AccessTokenInterface>jwt.decode(authorization);
+      if (dispatcher.company_id.id !== decodedToken.company_id.id) throw new BadRequestException("You doesn't work in this company");
+
+      await this.userRepo.update(id, { ...updateDriverDto });
+      return { status: 200, message: `Dispatcher ${dispatcher.full_name} updated successfully` };
+    } catch (error) {
+      throw new BadRequestException('There is no such dispatcher');
+    }
+  }
+
+  async remove(id: number, authorization: string): Promise<ResponseInterface> {
+    try {
+      const dispatcher = await this.userRepo.findOneByOrFail({ id });
+
+      const decodedToken = <AccessTokenInterface>jwt.decode(authorization);
+      if (dispatcher.company_id.id !== decodedToken.company_id.id) throw new BadRequestException("You doesn't work in this company");
+
+      await this.userRepo.delete(id);
+      return { status: 200, message: `Dispatcher ${dispatcher.full_name} account deleted successfully` };
+    } catch (error) {
+      throw new BadRequestException('There is no such dispatcher');
+    }
+  }
+}

--- a/src/modules/user/driver/driver.service.ts
+++ b/src/modules/user/driver/driver.service.ts
@@ -2,20 +2,11 @@ import { BadRequestException, Injectable, InternalServerErrorException } from '@
 import { InjectRepository } from '@nestjs/typeorm';
 import { Company } from 'common/database/entities/company.entity';
 import { User } from 'common/database/entities/user.entity';
-import { Roles } from 'common/enums/enums';
 import { ResponseInterface } from 'common/types/interfaces';
-import * as jwt from 'jsonwebtoken';
 import { EntityManager, Repository } from 'typeorm';
 
 import { CreateDriverDto } from './dto/create-driver.dto';
 import { UpdateDriverDto } from './dto/update-driver.dto';
-
-interface AccessTokenInterface extends jwt.Jwt {
-  fullName: string;
-  email: string;
-  role: Roles;
-  company_id: Company;
-}
 
 @Injectable()
 export class DriverService {
@@ -27,12 +18,9 @@ export class DriverService {
     private readonly entityManager: EntityManager,
   ) {}
 
-  async create(createDriverDto: CreateDriverDto, authorization: string): Promise<User> {
+  async create(createDriverDto: CreateDriverDto): Promise<User> {
     try {
       const company = await this.companyRepo.findOneByOrFail({ id: createDriverDto.company_id });
-
-      const decodedToken = <AccessTokenInterface>jwt.decode(authorization);
-      if (company.id !== decodedToken.company_id.id) throw new BadRequestException("You doesn't work in this company");
 
       const dispatcher = this.userRepo.create({ ...createDriverDto, company_id: company });
       return await this.entityManager.save(dispatcher);
@@ -41,24 +29,17 @@ export class DriverService {
     }
   }
 
-  async findOne(id: number, authorization: string): Promise<User> {
+  async findOne(id: number): Promise<User> {
     try {
-      const dispatcher = await this.userRepo.findOneByOrFail({ id });
-
-      const decodedToken = <AccessTokenInterface>jwt.decode(authorization);
-      if (dispatcher.company_id.id !== decodedToken.company_id.id) throw new BadRequestException("You doesn't work in this company");
       return await this.userRepo.findOneByOrFail({ id });
     } catch (error) {
       throw new BadRequestException('There is no such dispatcher');
     }
   }
 
-  async update(id: number, updateDriverDto: UpdateDriverDto, authorization: string): Promise<ResponseInterface> {
+  async update(id: number, updateDriverDto: UpdateDriverDto): Promise<ResponseInterface> {
     try {
       const dispatcher = await this.userRepo.findOneByOrFail({ id });
-
-      const decodedToken = <AccessTokenInterface>jwt.decode(authorization);
-      if (dispatcher.company_id.id !== decodedToken.company_id.id) throw new BadRequestException("You doesn't work in this company");
 
       await this.userRepo.update(id, { ...updateDriverDto });
       return { status: 200, message: `Dispatcher ${dispatcher.full_name} updated successfully` };
@@ -67,12 +48,9 @@ export class DriverService {
     }
   }
 
-  async remove(id: number, authorization: string): Promise<ResponseInterface> {
+  async remove(id: number): Promise<ResponseInterface> {
     try {
       const dispatcher = await this.userRepo.findOneByOrFail({ id });
-
-      const decodedToken = <AccessTokenInterface>jwt.decode(authorization);
-      if (dispatcher.company_id.id !== decodedToken.company_id.id) throw new BadRequestException("You doesn't work in this company");
 
       await this.userRepo.delete(id);
       return { status: 200, message: `Dispatcher ${dispatcher.full_name} account deleted successfully` };

--- a/src/modules/user/driver/dto/create-driver.dto.ts
+++ b/src/modules/user/driver/dto/create-driver.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsEmail, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { Roles } from 'common/enums/enums';
+
+export class CreateDriverDto {
+  @Expose()
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ example: 'https://logo-path', description: 'driver logo' })
+  logo: string;
+
+  @Expose()
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ example: 'John Doe', description: 'driver full name' })
+  full_name: string;
+
+  @Expose()
+  @IsString()
+  @IsEmail()
+  @ApiProperty({ example: 'example@gmail.com', description: 'driver email' })
+  email: string;
+
+  @Expose()
+  @IsString()
+  @ApiProperty({ example: Roles.DRIVER, description: 'driver role' })
+  role: Roles.DRIVER;
+
+  @Expose()
+  @IsNumber()
+  @ApiProperty({ example: 15, description: 'dispatcher company id' })
+  company_id: number;
+}

--- a/src/modules/user/driver/dto/update-driver.dto.ts
+++ b/src/modules/user/driver/dto/update-driver.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+
+export class UpdateDriverDto {
+  @Expose()
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ example: 'https://logo-path', description: 'dispatcher logo' })
+  logo: string;
+
+  @Expose()
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ example: 'John Doe', description: 'dispatcher full name' })
+  full_name: string;
+
+  @Expose()
+  @IsString()
+  @IsEmail()
+  @ApiProperty({ example: 'example@gmail.com', description: 'dispatcher email' })
+  email: string;
+}

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 
 import { AdminModule } from './admin/admin.module';
 import { DispatcherModule } from './dispatcher/dispatcher.module';
+import { DriverModule } from './driver/driver.module';
 import { UserService } from './user.service';
 
 @Module({
   providers: [UserService],
-  imports: [AdminModule, DispatcherModule],
+  imports: [AdminModule, DispatcherModule, DriverModule],
 })
 export class UserModule {}


### PR DESCRIPTION
## Describe your changes

- Create driver update driver get driver delete driver.
- Available only for admin or dispatcher from the same with driver company 

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://codecraftersintership.atlassian.net/browse/SCRUM-22)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [x] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [x] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
