### PR TITLE
+ Create: get drivers logic

### DIFF
--- a/src/modules/user/driver/driver.controller.ts
+++ b/src/modules/user/driver/driver.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, SetMetadata } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, SetMetadata, Query } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { User } from 'common/database/entities/user.entity';
 import { Roles } from 'common/enums/enums';
@@ -21,6 +21,15 @@ export class DriverController {
   @ApiResponse({ status: 201, type: User })
   async create(@Body() createDriverDto: CreateDriverDto): Promise<User> {
     return this.driverService.create(createDriverDto);
+  }
+
+  @Get('')
+  @UseGuards(RolesGuard, UserCompanyGuard)
+  @SetMetadata('roles', [Roles.ADMIN, Roles.DISPATCHER])
+  @ApiOperation({ summary: 'Get drivers' })
+  @ApiResponse({ status: 200, type: [User] })
+  async findAll(@Query() { sortBy, search, companyId }: { sortBy: 'ASC' | 'DESC'; search: string; companyId: number }): Promise<User[]> {
+    return this.driverService.findAll(sortBy, search, companyId);
   }
 
   @Get(':id')

--- a/src/modules/user/driver/driver.service.ts
+++ b/src/modules/user/driver/driver.service.ts
@@ -2,8 +2,9 @@ import { BadRequestException, Injectable, InternalServerErrorException } from '@
 import { InjectRepository } from '@nestjs/typeorm';
 import { Company } from 'common/database/entities/company.entity';
 import { User } from 'common/database/entities/user.entity';
+import { Roles } from 'common/enums/enums';
 import { ResponseInterface } from 'common/types/interfaces';
-import { EntityManager, Repository } from 'typeorm';
+import { EntityManager, Like, Repository } from 'typeorm';
 
 import { CreateDriverDto } from './dto/create-driver.dto';
 import { UpdateDriverDto } from './dto/update-driver.dto';
@@ -26,6 +27,17 @@ export class DriverService {
       return await this.entityManager.save(dispatcher);
     } catch (error) {
       throw new InternalServerErrorException('Internal server error');
+    }
+  }
+
+  async findAll(sortBy: 'ASC' | 'DESC', search: string, companyId: number): Promise<User[]> {
+    try {
+      return await this.userRepo.find({
+        where: { company_id: { id: companyId }, role: Roles.DRIVER, full_name: Like(`%${search}%`) },
+        order: { full_name: sortBy },
+      });
+    } catch (error) {
+      throw new BadRequestException('There is no such dispatcher');
     }
   }
 


### PR DESCRIPTION
## Describe your changes

- Create get drivers endpoint

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://codecraftersintership.atlassian.net/browse/SCRUM-46)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [x] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [x] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
