### PR TITLE
+ Update: getOrders by filters logic

### DIFF
--- a/src/common/utils/stringToBoolean.ts
+++ b/src/common/utils/stringToBoolean.ts
@@ -1,0 +1,1 @@
+export const stringToBoolean = (string: 'true' | 'false'): boolean => string === 'true';

--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -34,6 +34,6 @@ export class OrdersController {
   @ApiResponse({ status: 400, description: 'Invalid query parameters' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async findAll(@Query() queryParams: OrderQueryParams): Promise<{ orders: Order[]; page: number; pagesCount: number }> {
-    return this.ordersService.findAll(queryParams);
+    return this.ordersService.findAll({ ...queryParams, isNew: queryParams.isNew === 'true' });
   }
 }

--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -4,6 +4,7 @@ import { Order } from 'common/database/entities/order.entity';
 import { Roles } from 'common/enums/enums';
 import { RolesGuard } from 'common/guards/roles.guard';
 import { FailedResponse } from 'common/types/failed-response.dto';
+import { stringToBoolean } from 'common/utils/stringToBoolean';
 
 import { OrdersResponse } from './dto/response.dto';
 import { OrdersService } from './orders.service';
@@ -34,6 +35,6 @@ export class OrdersController {
   @ApiResponse({ status: 400, description: 'Invalid query parameters' })
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async findAll(@Query() queryParams: OrderQueryParams): Promise<{ orders: Order[]; page: number; pagesCount: number }> {
-    return this.ordersService.findAll({ ...queryParams, isNew: queryParams.isNew === 'true' });
+    return this.ordersService.findAll({ ...queryParams, isNew: stringToBoolean(queryParams.isNew) });
   }
 }

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { ORDER_PAGE_LENGTH } from 'common/constants/numbers';
 import { Order } from 'common/database/entities/order.entity';
 import { LuggageTypes, OrderStatuses } from 'common/enums/enums';
-import { FindManyOptions, Like, Repository } from 'typeorm';
+import { FindManyOptions, IsNull, Like, Repository } from 'typeorm';
 
 import { OrderQueryParams } from './types';
 
@@ -20,6 +20,7 @@ export class OrdersService {
     page,
     companyId,
     search,
+    isNew,
   }: OrderQueryParams): Promise<{ orders: Order[]; page: number; pagesCount: number }> {
     const findSettings: FindManyOptions<Order> = {
       skip: (page - 1) * ORDER_PAGE_LENGTH,
@@ -30,6 +31,7 @@ export class OrdersService {
             {
               status: OrderStatuses[filterBy],
               company: { id: companyId },
+              route: isNew === 'true' ? IsNull() : {},
               customer: {
                 full_name: Like(`%${search}%`),
               },
@@ -38,6 +40,7 @@ export class OrdersService {
               status: OrderStatuses[filterBy],
               company: { id: companyId },
               collection_address: Like(`%${search}%`),
+              route: isNew === 'true' ? IsNull() : {},
             },
             {
               status: OrderStatuses[filterBy],
@@ -45,6 +48,7 @@ export class OrdersService {
               luggages: {
                 luggage_type: <LuggageTypes>(<unknown>Like(`%${search}%`)),
               },
+              route: isNew === 'true' ? IsNull() : {},
             },
             {
               status: OrderStatuses[filterBy],
@@ -52,6 +56,7 @@ export class OrdersService {
               customer: {
                 phone_number: <LuggageTypes>(<unknown>Like(`%${search}%`)),
               },
+              route: isNew === 'true' ? IsNull() : {},
             },
             {
               status: OrderStatuses[filterBy],
@@ -59,6 +64,7 @@ export class OrdersService {
               customer: {
                 email: <LuggageTypes>(<unknown>Like(`%${search}%`)),
               },
+              route: isNew === 'true' ? IsNull() : {},
             },
             {
               status: OrderStatuses[filterBy],
@@ -78,9 +84,10 @@ export class OrdersService {
               status: OrderStatuses[filterBy],
               company: { id: companyId },
               collection_date: <Date>(<unknown>Like(`%${search}%`)),
+              route: isNew === 'true' ? IsNull() : {},
             },
           ]
-        : { status: OrderStatuses[filterBy], company: { id: companyId } },
+        : { status: OrderStatuses[filterBy], company: { id: companyId }, route: isNew === 'true' ? IsNull() : {} },
       order: { ...(<Record<string, string>>JSON.parse(sortBy)) },
     };
 

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -5,7 +5,7 @@ import { Order } from 'common/database/entities/order.entity';
 import { LuggageTypes, OrderStatuses } from 'common/enums/enums';
 import { FindManyOptions, IsNull, Like, Repository } from 'typeorm';
 
-import { OrderQueryParams } from './types';
+import { OrderServiceParams } from './types';
 
 @Injectable()
 export class OrdersService {
@@ -21,7 +21,7 @@ export class OrdersService {
     companyId,
     search,
     isNew,
-  }: OrderQueryParams): Promise<{ orders: Order[]; page: number; pagesCount: number }> {
+  }: OrderServiceParams): Promise<{ orders: Order[]; page: number; pagesCount: number }> {
     const findSettings: FindManyOptions<Order> = {
       skip: (page - 1) * ORDER_PAGE_LENGTH,
       take: ORDER_PAGE_LENGTH,
@@ -31,7 +31,7 @@ export class OrdersService {
             {
               status: OrderStatuses[filterBy],
               company: { id: companyId },
-              route: isNew === 'true' ? IsNull() : {},
+              route: isNew ? IsNull() : {},
               customer: {
                 full_name: Like(`%${search}%`),
               },
@@ -40,7 +40,7 @@ export class OrdersService {
               status: OrderStatuses[filterBy],
               company: { id: companyId },
               collection_address: Like(`%${search}%`),
-              route: isNew === 'true' ? IsNull() : {},
+              route: isNew ? IsNull() : {},
             },
             {
               status: OrderStatuses[filterBy],
@@ -48,7 +48,7 @@ export class OrdersService {
               luggages: {
                 luggage_type: <LuggageTypes>(<unknown>Like(`%${search}%`)),
               },
-              route: isNew === 'true' ? IsNull() : {},
+              route: isNew ? IsNull() : {},
             },
             {
               status: OrderStatuses[filterBy],
@@ -56,7 +56,7 @@ export class OrdersService {
               customer: {
                 phone_number: <LuggageTypes>(<unknown>Like(`%${search}%`)),
               },
-              route: isNew === 'true' ? IsNull() : {},
+              route: isNew ? IsNull() : {},
             },
             {
               status: OrderStatuses[filterBy],
@@ -64,7 +64,7 @@ export class OrdersService {
               customer: {
                 email: <LuggageTypes>(<unknown>Like(`%${search}%`)),
               },
-              route: isNew === 'true' ? IsNull() : {},
+              route: isNew ? IsNull() : {},
             },
             {
               status: OrderStatuses[filterBy],
@@ -84,10 +84,10 @@ export class OrdersService {
               status: OrderStatuses[filterBy],
               company: { id: companyId },
               collection_date: <Date>(<unknown>Like(`%${search}%`)),
-              route: isNew === 'true' ? IsNull() : {},
+              route: isNew ? IsNull() : {},
             },
           ]
-        : { status: OrderStatuses[filterBy], company: { id: companyId }, route: isNew === 'true' ? IsNull() : {} },
+        : { status: OrderStatuses[filterBy], company: { id: companyId }, route: isNew ? IsNull() : {} },
       order: { ...(<Record<string, string>>JSON.parse(sortBy)) },
     };
 

--- a/src/modules/orders/types.ts
+++ b/src/modules/orders/types.ts
@@ -6,4 +6,5 @@ export interface OrderQueryParams {
   search: string;
   page: number;
   companyId: number;
+  isNew: 'true' | 'false';
 }

--- a/src/modules/orders/types.ts
+++ b/src/modules/orders/types.ts
@@ -8,3 +8,12 @@ export interface OrderQueryParams {
   companyId: number;
   isNew: 'true' | 'false';
 }
+
+export interface OrderServiceParams {
+  sortBy: string;
+  filterBy: keyof typeof OrderStatuses;
+  search: string;
+  page: number;
+  companyId: number;
+  isNew: boolean;
+}

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,10 +1,10 @@
 import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ORDER_PAGE_LENGTH } from 'common/constants/numbers';
 import { User } from 'common/database/entities/user.entity';
 import { FindManyOptions, FindOptionsWhere, Like, Repository } from 'typeorm';
+
 import { UserQueryParams } from './types';
-import { ORDER_PAGE_LENGTH } from 'common/constants/numbers';
-import { Roles } from 'common/enums/enums';
 
 @Injectable()
 export class UserService {
@@ -21,7 +21,7 @@ export class UserService {
     let parsedSortBy: Record<string, 'ASC' | 'DESC'> = { full_name: 'ASC' };
     if (sortBy) {
       try {
-        parsedSortBy = JSON.parse(sortBy);
+        parsedSortBy = <Record<string, 'ASC' | 'DESC'>>JSON.parse(sortBy);
       } catch (error) {
         throw new BadRequestException('Invalid sortBy format');
       }
@@ -29,7 +29,7 @@ export class UserService {
 
     const whereCondition: FindOptionsWhere<User> = {
       ...(search && { full_name: Like(`%${search}%`) }),
-      ...(filterBy && { role: filterBy as Roles }),
+      ...(filterBy && { role: filterBy }),
       company_id: { id: companyId },
     };
 


### PR DESCRIPTION
## Describe your changes

- Update get orders endpoint

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://codecraftersintership.atlassian.net/browse/SCRUM-46)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [x] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [x] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
