### PR TITLE
feat:SCRUM-78 added authentification logic for driver

### DIFF
--- a/src/common/database/entities/user.entity.ts
+++ b/src/common/database/entities/user.entity.ts
@@ -30,6 +30,14 @@ export class User {
   @ApiProperty({ example: '+1234567890', description: 'user phone number' })
   phone_number?: string;
 
+  @Column({ nullable: true })
+  @ApiProperty({ example: '123456', description: 'OTP for driver authentication' })
+  otp?: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  @ApiProperty({ example: new Date(), description: 'OTP expiration time' })
+  otpExpiry?: Date;
+
   @ManyToOne(() => Company, (company) => company.id, { cascade: true, eager: true })
   @JoinColumn()
   @ApiProperty({ example: Company, description: 'user company' })

--- a/src/common/helpers/createEmailTemplates.ts
+++ b/src/common/helpers/createEmailTemplates.ts
@@ -12,6 +12,20 @@ export const createUserInvitationMail = ({ companyName, username, token }: { com
   Best regards, ${companyName} team`;
 };
 
+export const createDriverInvitationMail = ({ companyName, username, otp }: { companyName: string; username: string; otp: string }) => {
+  return `Welcome to ${companyName}!<br><br>
+
+  Dear ${username},Your account has been successfully registered! <br>
+  We warmly welcome you to ${companyName}!<br><br>
+  
+  Log in to ${companyName} by entering the verification code: ${otp}<br><br>
+  
+  If you have any queries or require assistance during the setup process, <br>
+  please do not hesitate to reply to this email. We are always available to assist you.<br><br>
+  
+  Best regards, ${companyName} team`;
+};
+
 export const createCompanyInvitationMail = (companyName: string) => {
   return `Welcome to Smartporters! <br><br>
 

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,11 +1,12 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from 'common/database/entities/user.entity';
 import { Roles } from 'common/enums/enums';
-import { createUserInvitationMail } from 'common/helpers/createEmailTemplates';
+import { createUserInvitationMail, createDriverInvitationMail } from 'common/helpers/createEmailTemplates';
 import { MailerService } from 'common/mailer/mailer.service';
 import { SuccessResponse } from 'common/types/response-success.dto';
+import * as crypto from 'crypto';
 import * as jwt from 'jsonwebtoken';
 import { Repository } from 'typeorm';
 
@@ -51,5 +52,90 @@ export class AuthService {
 
   tokenValidation(accessToken: string, role: Roles): { token: string; role: Roles } {
     return { token: accessToken, role };
+  }
+
+  async authDriverByEmail(email: string): Promise<SuccessResponse> {
+    try {
+      const user: User = await this.userRepo.findOneOrFail({ where: { email } });
+
+      if (user.role !== Roles.DRIVER) {
+        throw new BadRequestException("User with this email isn't a driver");
+      }
+
+      const userCompany: string = user.company_id.name;
+
+      const otp: string = this.generateOtp();
+      const otpExpiry = new Date();
+      const otpValidMinutes = 1;
+      otpExpiry.setMinutes(otpExpiry.getMinutes() + otpValidMinutes);
+
+      user.otp = otp;
+      user.otpExpiry = otpExpiry;
+
+      await this.userRepo.save(user);
+
+      await this.smtpService.sendEmail({
+        from: { name: this.configService.getOrThrow('APP_NAME'), address: this.configService.getOrThrow('DEFAULT_EMAIL_FROM') },
+        recipients: [{ name: user.full_name, address: user.email }],
+        subject: 'Invitation Link',
+        html: createDriverInvitationMail({
+          companyName: userCompany,
+          username: user.full_name,
+          otp,
+        }),
+        placeholderReplacements: {},
+      });
+
+      return { status: 200, message: 'You logged in successfully check your email' };
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      throw new InternalServerErrorException('Failed to send email to driver');
+    }
+  }
+
+  async verifyDriverOtp(email: string, otp: string): Promise<{ token: string; role: Roles }> {
+    try {
+      const user: User = await this.userRepo.findOneOrFail({ where: { email } });
+
+      if (user.role !== Roles.DRIVER) {
+        throw new BadRequestException("User with this email isn't a driver");
+      }
+
+      if (!!user.otpExpiry && (!user.otp || user.otpExpiry < new Date())) {
+        throw new BadRequestException('OTP expired or not found');
+      }
+
+      if (user.otp !== otp) {
+        throw new BadRequestException('Invalid OTP');
+      }
+
+      user.otp = undefined;
+      user.otpExpiry = undefined;
+      await this.userRepo.save(user);
+
+      const { role } = user;
+
+      const secret: string = this.configService.getOrThrow('JWT_SECRET');
+      const accessToken: string = jwt.sign(
+        { fullName: user.full_name, email: user.email, role: user.role, company_id: user.company_id },
+        secret,
+        {
+          expiresIn: '24h',
+        },
+      );
+
+      return { token: accessToken, role };
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      throw new InternalServerErrorException(`Failed to verify OTP`);
+    }
+  }
+
+  private generateOtp(): string {
+    return crypto.randomInt(100000, 999999).toString();
   }
 }

--- a/src/modules/auth/dto/auth-driver-response.dto.ts
+++ b/src/modules/auth/dto/auth-driver-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class AuthDriverResponseDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({
+    example: '121345',
+    description: 'Auth code for driver',
+  })
+  otp: string;
+}


### PR DESCRIPTION
## Describe your changes

- I added functionality for sending verification code via email for login driver.
- I added otp field(verification code) and otpExpiry to user entity 
![image](https://github.com/user-attachments/assets/f18fdb31-dc1b-485c-ad5b-4c577a7c0363)


## Issue ticket code (and/or) and link

- [SCRUM-78](https://codecraftersintership.atlassian.net/browse/SCRUM-78)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [ ] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [ ] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [ ] use @`@index` decorator for frequently requested data
- [ ] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [ ] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
