### PR TITLE
Feat/get route details

### DIFF
--- a/src/common/types/routeInformResponse.ts
+++ b/src/common/types/routeInformResponse.ts
@@ -1,0 +1,22 @@
+import { OrderStatuses, RouteStatuses } from 'common/enums/enums';
+
+export interface RouteInform {
+  id: number;
+  submission_date: Date;
+  arrival_date: Date;
+  distance: number;
+  status: RouteStatuses;
+  driver: {
+    id: number;
+    full_name: string;
+    email: string;
+  };
+  orders: {
+    id: number;
+    collection_date: Date;
+    collection_time_start: Date;
+    collection_time_end: Date;
+    collection_address: string;
+    status: OrderStatuses;
+  }[];
+}

--- a/src/common/utils/transformRouteObject.ts
+++ b/src/common/utils/transformRouteObject.ts
@@ -1,0 +1,25 @@
+import { Route } from 'common/database/entities/route.entity';
+import { RouteInform } from 'common/types/routeInformResponse';
+
+export const transformRouteObject = (routeObject: Route): RouteInform => {
+  return {
+    id: routeObject.id,
+    submission_date: routeObject.submission_date,
+    arrival_date: routeObject.arrival_date,
+    distance: routeObject.distance,
+    status: routeObject.status,
+    driver: {
+      id: routeObject.user_id.id,
+      full_name: routeObject.user_id.full_name,
+      email: routeObject.user_id.email,
+    },
+    orders: routeObject.orders.map((order) => ({
+      id: order.id,
+      collection_date: order.collection_date,
+      collection_time_start: order.collection_time_start,
+      collection_time_end: order.collection_time_end,
+      collection_address: order.collection_address,
+      status: order.status,
+    })),
+  };
+};

--- a/src/modules/route/route.controller.ts
+++ b/src/modules/route/route.controller.ts
@@ -3,11 +3,12 @@ import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Route } from 'common/database/entities/route.entity';
 import { Roles } from 'common/enums/enums';
 import { RolesGuard } from 'common/guards/roles.guard';
+import { FailedResponse } from 'common/types/failed-response.dto';
 import { SuccessResponse } from 'common/types/response-success.dto';
+import { RouteInform } from 'common/types/routeInformResponse';
 
 import { CreateRouteDto } from './dto/create-route.dto';
 import { RouteService } from './route.service';
-import { FailedResponse } from 'common/types/failed-response.dto';
 
 @Controller('route')
 export class RouteController {
@@ -28,7 +29,7 @@ export class RouteController {
   @ApiOperation({ summary: 'Route route details' })
   @ApiResponse({ status: 200, example: { status: 200, type: Route } })
   @ApiResponse({ status: 400, type: FailedResponse })
-  async getRouteDetails(@Param('id') id: number): Promise<Route> {
+  async getRouteDetails(@Param('id') id: number): Promise<RouteInform> {
     return this.routeService.getOne(+id);
   }
 }

--- a/src/modules/route/route.controller.ts
+++ b/src/modules/route/route.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, UseGuards, SetMetadata } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards, SetMetadata, Get, Param } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Roles } from 'common/enums/enums';
 import { RolesGuard } from 'common/guards/roles.guard';
@@ -6,6 +6,7 @@ import { SuccessResponse } from 'common/types/response-success.dto';
 
 import { CreateRouteDto } from './dto/create-route.dto';
 import { RouteService } from './route.service';
+import { Route } from 'common/database/entities/route.entity';
 
 @Controller('route')
 export class RouteController {
@@ -18,5 +19,10 @@ export class RouteController {
   @ApiResponse({ status: 201, example: { status: 201, message: 'Routes created successfully' } })
   async create(@Body() createRouteDto: CreateRouteDto[]): Promise<SuccessResponse> {
     return this.routeService.create(createRouteDto);
+  }
+
+  @Get(':id')
+  async getRouteDetails(@Param('id') id: number): Promise<Route> {
+    return this.routeService.getOne(+id);
   }
 }

--- a/src/modules/route/route.controller.ts
+++ b/src/modules/route/route.controller.ts
@@ -1,12 +1,13 @@
 import { Controller, Post, Body, UseGuards, SetMetadata, Get, Param } from '@nestjs/common';
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Route } from 'common/database/entities/route.entity';
 import { Roles } from 'common/enums/enums';
 import { RolesGuard } from 'common/guards/roles.guard';
 import { SuccessResponse } from 'common/types/response-success.dto';
 
 import { CreateRouteDto } from './dto/create-route.dto';
 import { RouteService } from './route.service';
-import { Route } from 'common/database/entities/route.entity';
+import { FailedResponse } from 'common/types/failed-response.dto';
 
 @Controller('route')
 export class RouteController {
@@ -22,6 +23,11 @@ export class RouteController {
   }
 
   @Get(':id')
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.ADMIN, Roles.DISPATCHER])
+  @ApiOperation({ summary: 'Route route details' })
+  @ApiResponse({ status: 200, example: { status: 200, type: Route } })
+  @ApiResponse({ status: 400, type: FailedResponse })
   async getRouteDetails(@Param('id') id: number): Promise<Route> {
     return this.routeService.getOne(+id);
   }

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -2,6 +2,8 @@ import { BadRequestException, Injectable, InternalServerErrorException } from '@
 import { InjectRepository } from '@nestjs/typeorm';
 import { Route } from 'common/database/entities/route.entity';
 import { SuccessResponse } from 'common/types/response-success.dto';
+import { RouteInform } from 'common/types/routeInformResponse';
+import { transformRouteObject } from 'common/utils/transformRouteObject';
 import { EntityManager, EntityNotFoundError, Repository } from 'typeorm';
 
 import { CreateRouteDto } from './dto/create-route.dto';
@@ -28,12 +30,14 @@ export class RouteService {
     }
   }
 
-  async getOne(id: number): Promise<Route> {
+  async getOne(id: number): Promise<RouteInform> {
     try {
-      return await this.routeRepo.findOneOrFail({
+      const route = await this.routeRepo.findOneOrFail({
         where: { id },
         relations: ['orders'],
       });
+
+      return transformRouteObject(route);
     } catch (error: unknown) {
       if (error instanceof EntityNotFoundError) {
         throw new BadRequestException(error.message);

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -1,8 +1,8 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Route } from 'common/database/entities/route.entity';
 import { SuccessResponse } from 'common/types/response-success.dto';
-import { EntityManager, Repository } from 'typeorm';
+import { EntityManager, EntityNotFoundError, Repository } from 'typeorm';
 
 import { CreateRouteDto } from './dto/create-route.dto';
 
@@ -25,6 +25,20 @@ export class RouteService {
       return { status: 201, message: 'Routes have been successfully created!' };
     } catch (error) {
       throw new InternalServerErrorException(error);
+    }
+  }
+
+  async getOne(id: number): Promise<Route> {
+    try {
+      return await this.routeRepo.findOneOrFail({
+        where: { id },
+        relations: ['orders'],
+      });
+    } catch (error: unknown) {
+      if (error instanceof EntityNotFoundError) {
+        throw new BadRequestException(error.message);
+      }
+      throw new InternalServerErrorException("Can't get route details");
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

- Create get route details endpoint

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://codecraftersintership.atlassian.net/browse/SCRUM-53)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [x] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [x] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
