### PR TITLE
feat:SCRUM-84-DR-Orders-BE

### DIFF
--- a/src/common/types/interfaces.ts
+++ b/src/common/types/interfaces.ts
@@ -20,3 +20,12 @@ export interface ResponseInterface {
   message?: string;
   error?: unknown;
 }
+
+export interface OrderWithRouteAndCustomer {
+  orderId: number;
+  routeId: number;
+  collectionTimeStart: Date;
+  collectionTimeEnd: Date;
+  customerName: string;
+  customerPhone: string | null;
+}

--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -7,6 +7,7 @@ import { Roles } from 'common/enums/enums';
 import { RolesGuard } from 'common/guards/roles.guard';
 import { AssignedOrdersResponse } from 'common/types/assignedOrdersResponse';
 import { FailedResponse } from 'common/types/failed-response.dto';
+import { OrderWithRouteAndCustomer } from 'common/types/interfaces';
 import { stringToBoolean } from 'common/utils/stringToBoolean';
 
 import { OrdersResponse } from './dto/response.dto';
@@ -74,5 +75,32 @@ export class OrdersController {
     @ParseAssignOrdersJson() { driversIds, ordersIds }: { driversIds: number[]; ordersIds: number[] },
   ): Promise<AssignedOrdersResponse> {
     return this.ordersService.getAndAssign(driversIds, ordersIds);
+  }
+
+  @Get('by-driver')
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.ADMIN, Roles.DRIVER])
+  @ApiOperation({ summary: 'Get orders assigned for the driver on the selected date' })
+  @ApiQuery({ name: 'date', description: 'Date for handling orders only for assigned date', example: new Date().toISOString() })
+  @ApiQuery({ name: 'driverId', description: 'Driver id to get orders assigned to appropriate driver', example: 1 })
+  @ApiResponse({
+    status: 200,
+    example: {
+      orders: [
+        {
+          orderId: 1,
+          routeId: 1,
+          collectionTimeStart: new Date(),
+          collectionTimeEnd: new Date(),
+          customerName: 'Customer Name',
+          customerPhone: '+12345678',
+        },
+      ],
+    },
+  })
+  @ApiResponse({ status: 500, type: FailedResponse })
+  async findOrdersByDriverAndDate(@Query() { date, driverId }: { date: Date; driverId: number }): Promise<OrderWithRouteAndCustomer[]> {
+    const parsedDate = new Date(date);
+    return this.ordersService.getOrdersByDriverAndDate(driverId, parsedDate);
   }
 }

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -5,6 +5,7 @@ import { Order } from 'common/database/entities/order.entity';
 import { User } from 'common/database/entities/user.entity';
 import { LuggageTypes, OrderStatuses } from 'common/enums/enums';
 import { AssignedOrdersResponse } from 'common/types/assignedOrdersResponse';
+import { OrderWithRouteAndCustomer } from 'common/types/interfaces';
 import { FindManyOptions, IsNull, Like, Between, Not, Repository } from 'typeorm';
 
 import { OrderServiceParams } from './types';
@@ -221,6 +222,37 @@ export class OrdersService {
       return this.assignOrdersToDrivers(drivers, orders);
     } catch (error) {
       throw new InternalServerErrorException('something went wrong');
+    }
+  }
+
+  async getOrdersByDriverAndDate(driverId: number, date: Date): Promise<OrderWithRouteAndCustomer[]> {
+    const startOfDay = new Date(date);
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const endOfDay = new Date(date);
+    endOfDay.setHours(23, 59, 59, 999);
+
+    try {
+      return await this.orderRepository
+        .createQueryBuilder('order')
+        .leftJoinAndSelect('order.route', 'route')
+        .leftJoinAndSelect('order.customer', 'customer')
+        .where('route.user_id = :driverId', { driverId })
+        .andWhere('order.collection_date BETWEEN :startOfDay AND :endOfDay', {
+          startOfDay,
+          endOfDay,
+        })
+        .select([
+          'order.id AS orderId',
+          'route.id AS routeId',
+          'order.collection_time_start AS collectionTimeStart',
+          'order.collection_time_end AS collectionTimeEnd',
+          'customer.full_name AS customerName',
+          'customer.phone_number AS customerPhone',
+        ])
+        .getRawMany<OrderWithRouteAndCustomer>();
+    } catch (error) {
+      throw new InternalServerErrorException('Internal Server Error');
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

- Modified orders.controller and orders.service by adding query for getting orders data by driver id and order date.
- Added new interface

## Issue ticket code (and/or) and link

- [SCRUM-84: DR Orders: BE](https://codecraftersintership.atlassian.net/browse/SCRUM-84)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [x] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [x] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
