### PR TITLE
+ Create: get routes by chose date range endpoint

### DIFF
--- a/src/common/decorators/parseDate.ts
+++ b/src/common/decorators/parseDate.ts
@@ -1,0 +1,38 @@
+import { BadRequestException, createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { isDateValid } from 'common/helpers/isDateValid';
+import { Request } from 'express';
+
+export const parseDate = createParamDecorator((_, ctx: ExecutionContext) => {
+  const request = ctx.switchToHttp().getRequest<Request>();
+  const from = request.query['from'] ? request.query['from'] : null;
+  const to = request.query['to'] ? request.query['to'] : null;
+
+  if (!from) {
+    throw new BadRequestException('Missing driversIds query parameter');
+  }
+  if (!to) {
+    throw new BadRequestException('Missing ordersIds query parameter');
+  }
+
+  let parsedFromDate: Date;
+  let parsedToDate: Date;
+  try {
+    parsedFromDate = new Date(<string>from);
+    if (!isDateValid(parsedFromDate)) {
+      throw new Error();
+    }
+  } catch {
+    throw new BadRequestException('Invalid JSON array for driversIds');
+  }
+
+  try {
+    parsedToDate = new Date(<string>to);
+    if (!isDateValid(parsedToDate)) {
+      throw new Error();
+    }
+  } catch {
+    throw new BadRequestException('Invalid JSON array for ordersIds');
+  }
+
+  return { from: parsedFromDate, to: parsedToDate };
+});

--- a/src/common/helpers/isDateValid.ts
+++ b/src/common/helpers/isDateValid.ts
@@ -1,0 +1,3 @@
+export const isDateValid = (date: Date): boolean => {
+  return typeof date.toString() === 'string';
+};

--- a/src/modules/route/route.controller.ts
+++ b/src/modules/route/route.controller.ts
@@ -17,6 +17,7 @@ import { ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import { Route } from 'common/database/entities/route.entity';
 import { Roles } from 'common/enums/enums';
 import { RolesGuard } from 'common/guards/roles.guard';
+import { UserCompanyGuard } from 'common/guards/userCompany.guard';
 import { FailedResponse } from 'common/types/failed-response.dto';
 import { SuccessResponse } from 'common/types/response-success.dto';
 import { RouteInform } from 'common/types/routeInformResponse';
@@ -85,6 +86,16 @@ export class RouteController {
     }
 
     return this.routeService.getRoutesByDateRange(start, end, sortField, sortDirection, searchQuery, drivers, stopsCount, statuses);
+  }
+
+  @Get('by-date-range')
+  @UseGuards(RolesGuard, UserCompanyGuard)
+  @SetMetadata('roles', [Roles.ADMIN, Roles.DISPATCHER])
+  @ApiOperation({ summary: 'Route route details' })
+  @ApiResponse({ status: 200, example: { status: 200, type: [Route] } })
+  @ApiResponse({ status: 400, type: FailedResponse })
+  async getRoutesForRender(@Query('from') from: Date, @Query('to') to: Date): Promise<RouteInform[]> {
+    return this.routeService.getRoutesForRender(from, to);
   }
 
   @Get(':id')

--- a/src/modules/route/route.controller.ts
+++ b/src/modules/route/route.controller.ts
@@ -15,6 +15,7 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import { Route } from 'common/database/entities/route.entity';
+import { parseDate } from 'common/decorators/parseDate';
 import { Roles } from 'common/enums/enums';
 import { RolesGuard } from 'common/guards/roles.guard';
 import { UserCompanyGuard } from 'common/guards/userCompany.guard';
@@ -94,7 +95,7 @@ export class RouteController {
   @ApiOperation({ summary: 'Route route details' })
   @ApiResponse({ status: 200, example: { status: 200, type: [Route] } })
   @ApiResponse({ status: 400, type: FailedResponse })
-  async getRoutesForRender(@Query('from') from: Date, @Query('to') to: Date): Promise<RouteInform[]> {
+  async getRoutesForRender(@parseDate() { from, to }: { from: Date; to: Date }): Promise<RouteInform[]> {
     return this.routeService.getRoutesForRender(from, to);
   }
 

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -12,7 +12,7 @@ import { MailerService } from 'common/mailer/mailer.service';
 import { SuccessResponse } from 'common/types/response-success.dto';
 import { RouteInform } from 'common/types/routeInformResponse';
 import { transformRouteObject } from 'common/utils/transformRouteObject';
-import { DeleteResult, EntityManager, EntityNotFoundError, In, Repository } from 'typeorm';
+import { DeleteResult, EntityManager, EntityNotFoundError, In, Repository, Between } from 'typeorm';
 
 import { CreateRouteDto } from './dto/create-route.dto';
 import { ErrorResponse } from './dto/error-response.dto';
@@ -268,6 +268,23 @@ export class RouteService {
       return { status: 200, message: 'route deleted successfully' };
     } catch (error) {
       throw new NotFoundException('There is no such route');
+    }
+  }
+
+  async getRoutesForRender(from: Date, to: Date): Promise<RouteInform[]> {
+    try {
+      const startDate = new Date(new Date(from).setHours(0, 0, 0, 0));
+      const endDate = new Date(to);
+      const routes = await this.routeRepo.find({
+        where: {
+          arrival_date: Between(startDate, endDate),
+        },
+        relations: ['orders'],
+      });
+
+      return routes.map((route) => transformRouteObject(route));
+    } catch (error) {
+      throw new InternalServerErrorException('');
     }
   }
 }

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -273,11 +273,10 @@ export class RouteService {
 
   async getRoutesForRender(from: Date, to: Date): Promise<RouteInform[]> {
     try {
-      const startDate = new Date(new Date(from).setHours(0, 0, 0, 0));
-      const endDate = new Date(to);
+      const startDate = new Date(from.setHours(0, 0, 0, 0));
       const routes = await this.routeRepo.find({
         where: {
-          arrival_date: Between(startDate, endDate),
+          arrival_date: Between(startDate, to),
         },
         relations: ['orders'],
       });


### PR DESCRIPTION
## Describe your changes

- Create get 'by-date-range' endpoint

## Issue ticket code (and/or) and link

- [Add functionality for the "Map view" button on the routes list page](https://codecraftersintership.atlassian.net/browse/SCRUM-132?atlOrigin=eyJpIjoiMWQ4MmY1Y2QwNTY5NGYzMjg5NGU2OTRhZjMyMzZhZDEiLCJwIjoiaiJ9)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [x] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [x] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
