### PR TITLE
feat: SCRUM-153 update route status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ EMAIL_PASS=adwa awds dsaw dawd //just example
 
 FE_LINK=5173
 
-DEFAULT_EMAIL_FROM=lohanecapho2000@gmail.com
+DEFAULT_EMAIL_FROM=dreamteam4gm@gmail.com
 APP_NAME=LogisticApp
 
 JWT_SECRET=123sdaas

--- a/src/common/types/not-found-response.ts
+++ b/src/common/types/not-found-response.ts
@@ -1,0 +1,10 @@
+import { NotFoundException } from '@nestjs/common';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class NotFoundResponse {
+  @ApiProperty({ example: 404, description: 'response status' })
+  status: number;
+
+  @ApiProperty({ example: new NotFoundException('There is no such route').getResponse(), description: 'response error (optional)' })
+  error?: unknown;
+}

--- a/src/modules/route/dto/update-route-status.dto.ts
+++ b/src/modules/route/dto/update-route-status.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsEnum, IsNotEmpty, IsNumber } from 'class-validator';
+import { RouteStatuses } from 'common/enums/enums';
+
+export class UpdateRouteStatusDto {
+  @Expose()
+  @IsNumber()
+  @IsNotEmpty()
+  @ApiProperty({ example: 1, description: 'driver id' })
+  driverId: number;
+
+  @Expose()
+  @IsEnum(RouteStatuses, { each: true })
+  @IsNotEmpty()
+  @ApiProperty({ example: RouteStatuses.ON_TIME, description: 'Route status for update' })
+  status: RouteStatuses;
+}

--- a/src/modules/route/route.controller.ts
+++ b/src/modules/route/route.controller.ts
@@ -20,10 +20,12 @@ import { Roles } from 'common/enums/enums';
 import { RolesGuard } from 'common/guards/roles.guard';
 import { UserCompanyGuard } from 'common/guards/userCompany.guard';
 import { FailedResponse } from 'common/types/failed-response.dto';
+import { NotFoundResponse } from 'common/types/not-found-response';
 import { SuccessResponse } from 'common/types/response-success.dto';
 import { RouteInform } from 'common/types/routeInformResponse';
 
 import { CreateRouteDto } from './dto/create-route.dto';
+import { UpdateRouteStatusDto } from './dto/update-route-status.dto';
 import { RouteService } from './route.service';
 import { RouteData } from './types';
 
@@ -115,8 +117,8 @@ export class RouteController {
   @ApiOperation({ summary: 'Route details for driver' })
   @ApiResponse({ status: 200, example: { status: 200, type: Route } })
   @ApiResponse({ status: 400, type: FailedResponse })
-  async getRouteDetailsForDriver(@Param('id') userId: number): Promise<RouteInform> {
-    return this.routeService.getOneForDriver(+userId);
+  async getRouteDetailsForDriver(@Param('id', ParseIntPipe) userId: number): Promise<RouteInform> {
+    return this.routeService.getOneForDriver(userId);
   }
 
   @Patch(':id')
@@ -127,6 +129,17 @@ export class RouteController {
   @ApiResponse({ status: 400, type: FailedResponse })
   async updateRoute(@Param('id', ParseIntPipe) id: number, @Query('orderId', ParseIntPipe) orderId: number): Promise<RouteInform> {
     return this.routeService.removeOrderFromRoute(id, orderId);
+  }
+
+  @Patch('driver/:id')
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.DRIVER, Roles.ADMIN, Roles.DISPATCHER])
+  @ApiOperation({ summary: 'Update route status' })
+  @ApiResponse({ status: 200, example: { status: 200, type: Route } })
+  @ApiResponse({ status: 400, type: FailedResponse })
+  @ApiResponse({ status: 404, type: NotFoundResponse })
+  async updateRouteStatus(@Param('id', ParseIntPipe) id: number, @Body() updateRouteStatusDto: UpdateRouteStatusDto): Promise<RouteInform> {
+    return this.routeService.updateRouteStatus(id, updateRouteStatusDto);
   }
 
   @Delete(':id')

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -16,6 +16,7 @@ import { DeleteResult, EntityManager, EntityNotFoundError, In, Repository, Betwe
 
 import { CreateRouteDto } from './dto/create-route.dto';
 import { ErrorResponse } from './dto/error-response.dto';
+import { UpdateRouteStatusDto } from './dto/update-route-status.dto';
 import { FilterData, RouteData } from './types';
 
 @Injectable()
@@ -86,17 +87,23 @@ export class RouteService {
 
   async getOneForDriver(id: number): Promise<RouteInform> {
     try {
-      const route = await this.routeRepo.findOneOrFail({
+      const route = await this.routeRepo.findOne({
         where: { user_id: { id } },
         relations: ['orders'],
       });
 
+      if (!route) {
+        throw new NotFoundException('There is no such route');
+      }
       return transformRouteObject(route);
     } catch (error: unknown) {
       if (error instanceof EntityNotFoundError) {
         throw new BadRequestException(error.message);
       }
-      throw new InternalServerErrorException("Can't get route details for driver");
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException(error.message);
+      }
+      throw new InternalServerErrorException('Something went wrong');
     }
   }
 
@@ -248,6 +255,19 @@ export class RouteService {
           await this.entityManager.save(updatedRoute);
         }
       });
+
+      return await this.getOne(routeId);
+    } catch (error) {
+      throw new NotFoundException('There is no such order');
+    }
+  }
+
+  async updateRouteStatus(routeId: number, updateRouteStatusDto: UpdateRouteStatusDto): Promise<RouteInform> {
+    try {
+      const route = await this.routeRepo.findOneOrFail({ where: { id: routeId, user_id: { id: updateRouteStatusDto.driverId } } });
+
+      route.status = updateRouteStatusDto.status;
+      await this.entityManager.save(route);
 
       return await this.getOne(routeId);
     } catch (error) {

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -271,7 +271,7 @@ export class RouteService {
 
       return await this.getOne(routeId);
     } catch (error) {
-      throw new NotFoundException('There is no such order');
+      throw new NotFoundException('There is no such route');
     }
   }
 


### PR DESCRIPTION
## Describe your changes

- I added functionality for updating route status.

## Issue ticket code (and/or) and link

- [SCRUM-153](https://codecraftersintership.atlassian.net/browse/SCRUM-153)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [ ] use @`@index` decorator for frequently requested data
- [ ] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [ ] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
