### PR TITLE
Feat/failed reasons be

### DIFF
--- a/src/common/database/entities/order.entity.ts
+++ b/src/common/database/entities/order.entity.ts
@@ -35,6 +35,9 @@ export class Order {
   @Column({ nullable: false, default: 'files/tickets/image 30.png' })
   ticket_photo: string;
 
+  @Column({ type: 'text', nullable: true })
+  failed_reason: string | null;
+
   @ManyToOne(() => Customer, (customer) => customer.id, { cascade: true, eager: true, nullable: false })
   @JoinColumn()
   customer: Customer;

--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseIntPipe, Query, SetMetadata, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Post, Query, SetMetadata, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Order } from 'common/database/entities/order.entity';
 import { User } from 'common/database/entities/user.entity';
@@ -128,5 +128,15 @@ export class OrdersController {
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async getNewOrdersCount(@Query('companyId') companyId: number): Promise<number> {
     return this.ordersService.getNewOrdersCount(companyId);
+  }
+
+  @Post('failed-reason')
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.DRIVER])
+  @ApiResponse({ status: 201, description: 'Failure reason saved successfully' })
+  @ApiResponse({ status: 404, description: 'Order not found' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async setFailedReason(@Body('orderId') orderId: number, @Body('reason') reason: string): Promise<Order> {
+    return this.ordersService.setFailedReason(orderId, reason);
   }
 }

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -8,7 +8,7 @@ import { LuggageTypes, OrderStatuses } from 'common/enums/enums';
 import { AssignedOrdersResponse } from 'common/types/assignedOrdersResponse';
 import { OrderWithRouteAndCustomer } from 'common/types/interfaces';
 import { tranformOrderObject, TransformedOrder } from 'common/utils/transformOrderObject';
-import { FindManyOptions, IsNull, Like, Between, Not, Repository } from 'typeorm';
+import { FindManyOptions, IsNull, Like, Between, Not, Repository, EntityNotFoundError } from 'typeorm';
 
 import { OrderServiceParams } from './types';
 
@@ -296,18 +296,14 @@ export class OrdersService {
 
   async setFailedReason(orderId: number, reason: string): Promise<Order> {
     try {
-      const order = await this.orderRepository.findOne({ where: { id: orderId } });
-
-      if (!order) {
-        throw new NotFoundException('Order not found');
-      }
+      const order = await this.orderRepository.findOneOrFail({ where: { id: orderId } });
 
       order.failed_reason = reason;
 
       return await this.orderRepository.save(order);
     } catch (error) {
-      if (error instanceof NotFoundException) {
-        throw error;
+      if (error instanceof EntityNotFoundError) {
+        throw new NotFoundException('Order not found');
       }
       throw new InternalServerErrorException('Something went wrong while updating the order.');
     }

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -293,4 +293,23 @@ export class OrdersService {
       throw new InternalServerErrorException('Internal Server Error');
     }
   }
+
+  async setFailedReason(orderId: number, reason: string): Promise<Order> {
+    try {
+      const order = await this.orderRepository.findOne({ where: { id: orderId } });
+
+      if (!order) {
+        throw new NotFoundException('Order not found');
+      }
+
+      order.failed_reason = reason;
+
+      return await this.orderRepository.save(order);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      throw new InternalServerErrorException('Something went wrong while updating the order.');
+    }
+  }
 }


### PR DESCRIPTION
## Describe your changes

- Add column failed_reason to order entity.
- Create API endpoint for setting failed order reason.

![photo_2024-12-23_21-39-35](https://github.com/user-attachments/assets/68a2f6db-c93f-44e2-bf8a-dbc6bf3fedb3)

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://codecraftersintership.atlassian.net/browse/SCRUM-143)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [x] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [ ] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
