### PR TITLE
feat:SCRUM-195 updated logic of getting route for driver

### DIFF
--- a/src/modules/route/route.controller.ts
+++ b/src/modules/route/route.controller.ts
@@ -111,14 +111,17 @@ export class RouteController {
     return this.routeService.getOne(+id);
   }
 
-  @Get('driver/:id')
+  @Get('driver/:driverId/:routeId')
   @UseGuards(RolesGuard)
   @SetMetadata('roles', [Roles.DRIVER])
-  @ApiOperation({ summary: 'Route details for driver' })
+  @ApiOperation({ summary: 'Route details for driver and specific route' })
   @ApiResponse({ status: 200, example: { status: 200, type: Route } })
   @ApiResponse({ status: 400, type: FailedResponse })
-  async getRouteDetailsForDriver(@Param('id', ParseIntPipe) userId: number): Promise<RouteInform> {
-    return this.routeService.getOneForDriver(userId);
+  async getRouteDetailsForDriver(
+    @Param('driverId', ParseIntPipe) driverId: number,
+    @Param('routeId', ParseIntPipe) routeId: number,
+  ): Promise<RouteInform> {
+    return this.routeService.getOneForDriver(driverId, routeId);
   }
 
   @Patch(':id')

--- a/src/modules/route/route.controller.ts
+++ b/src/modules/route/route.controller.ts
@@ -111,15 +111,15 @@ export class RouteController {
     return this.routeService.getOne(+id);
   }
 
-  @Get('driver/:driverId/:routeId')
+  @Get('driver/:routeId')
   @UseGuards(RolesGuard)
   @SetMetadata('roles', [Roles.DRIVER])
   @ApiOperation({ summary: 'Route details for driver and specific route' })
   @ApiResponse({ status: 200, example: { status: 200, type: Route } })
   @ApiResponse({ status: 400, type: FailedResponse })
   async getRouteDetailsForDriver(
-    @Param('driverId', ParseIntPipe) driverId: number,
     @Param('routeId', ParseIntPipe) routeId: number,
+    @Query('driverId', ParseIntPipe) driverId: number,
   ): Promise<RouteInform> {
     return this.routeService.getOneForDriver(driverId, routeId);
   }

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -87,7 +87,7 @@ export class RouteService {
 
   async getOneForDriver(driverId: number, routeId: number): Promise<RouteInform> {
     try {
-      const route = await this.routeRepo.findOne({
+      const route = await this.routeRepo.findOneOrFail({
         where: {
           user_id: { id: driverId },
           id: routeId,
@@ -95,17 +95,10 @@ export class RouteService {
         relations: ['orders'],
       });
 
-      if (!route) {
-        throw new NotFoundException('There is no such route');
-      }
-
       return transformRouteObject(route);
-    } catch (error: unknown) {
+    } catch (error) {
       if (error instanceof EntityNotFoundError) {
-        throw new BadRequestException(error.message);
-      }
-      if (error instanceof NotFoundException) {
-        throw new NotFoundException(error.message);
+        throw new NotFoundException('There is no such route');
       }
       throw new InternalServerErrorException('Something went wrong');
     }

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -85,16 +85,20 @@ export class RouteService {
     }
   }
 
-  async getOneForDriver(id: number): Promise<RouteInform> {
+  async getOneForDriver(driverId: number, routeId: number): Promise<RouteInform> {
     try {
       const route = await this.routeRepo.findOne({
-        where: { user_id: { id } },
+        where: {
+          user_id: { id: driverId },
+          id: routeId,
+        },
         relations: ['orders'],
       });
 
       if (!route) {
         throw new NotFoundException('There is no such route');
       }
+
       return transformRouteObject(route);
     } catch (error: unknown) {
       if (error instanceof EntityNotFoundError) {


### PR DESCRIPTION
## Describe your changes

- I updated logic of getting current route for the driver.

## Issue ticket code (and/or) and link

- [SCRUM-195](https://codecraftersintership.atlassian.net/browse/SCRUM-195)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [ ] use @`@index` decorator for frequently requested data
- [ ] use transactions if there is a call chain that mutates data in different tables
- [ ] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [ ] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
