### PR TITLE
* Fix: assign orders to drivers logic

### DIFF
--- a/src/common/database/entities/user.entity.ts
+++ b/src/common/database/entities/user.entity.ts
@@ -10,7 +10,7 @@ export class User {
   @ApiProperty({ example: 1, description: 'user id' })
   id: number;
 
-  @Column({ nullable: false })
+  @Column({ nullable: false, default: '' })
   @ApiProperty({ example: 'John Doe', description: 'user full name' })
   full_name: string;
 

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -193,27 +193,37 @@ export class OrdersService {
     }));
 
     const notAssignedOrders: Order[] = [];
-    const driverCount = drivers.length;
-    for (const order of orders) {
+
+    let orderIndex = 0;
+    for (const assignment of assignments) {
+      if (orderIndex < orders.length) {
+        assignment.orders.push(orders[orderIndex]);
+        orderIndex += 1;
+      }
+    }
+
+    while (orderIndex < orders.length) {
       let assigned = false;
 
-      for (let i = 0; i < driverCount; i += 1) {
-        const assignment = assignments[i];
+      for (const assignment of assignments) {
         const driverOrders = assignment.orders;
+        const currentOrder = orders[orderIndex];
 
         const hasSameStartTime = driverOrders.some(
-          (o) => new Date(o.collection_time_start).getTime() === new Date(order.collection_time_start).getTime(),
+          (o) => new Date(o.collection_time_start).getTime() === new Date(currentOrder.collection_time_start).getTime(),
         );
 
         if (!hasSameStartTime) {
-          assignment.orders.push(order);
+          assignment.orders.push(currentOrder);
           assigned = true;
+          orderIndex += 1;
           break;
         }
       }
 
       if (!assigned) {
-        notAssignedOrders.push(order);
+        notAssignedOrders.push(orders[orderIndex]);
+        orderIndex += 1;
       }
     }
 

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -7,12 +7,10 @@ import { Order } from 'common/database/entities/order.entity';
 import { Route } from 'common/database/entities/route.entity';
 import { User } from 'common/database/entities/user.entity';
 import { SortOrder } from 'common/enums/enums';
-import { createRouteNotificationMail } from 'common/helpers/createEmailTemplates';
-import { MailerService } from 'common/mailer/mailer.service';
 import { SuccessResponse } from 'common/types/response-success.dto';
 import { RouteInform } from 'common/types/routeInformResponse';
 import { transformRouteObject } from 'common/utils/transformRouteObject';
-import { DeleteResult, EntityManager, EntityNotFoundError, In, Repository, Between } from 'typeorm';
+import { DeleteResult, EntityManager, EntityNotFoundError, Repository, Between } from 'typeorm';
 
 import { CreateRouteDto } from './dto/create-route.dto';
 import { ErrorResponse } from './dto/error-response.dto';
@@ -27,10 +25,8 @@ export class RouteService {
     @InjectRepository(Order)
     private readonly orderRepo: Repository<Order>,
     @InjectRepository(User)
-    private readonly userRepo: Repository<User>,
     private readonly entityManager: EntityManager,
     private readonly configService: ConfigService,
-    private readonly smtpService: MailerService,
   ) {}
 
   async create(createRouteDto: CreateRouteDto[]): Promise<SuccessResponse> {
@@ -39,28 +35,6 @@ export class RouteService {
 
       for (const route of routes) {
         await this.routeRepo.save(route);
-      }
-      await this.entityManager.save(routes);
-
-      const driverIds = [...new Set(routes.map((route) => route.user_id))].filter(Boolean);
-
-      const users = await this.userRepo.find({
-        where: { id: In(driverIds) },
-      });
-
-      for (const user of users) {
-        await this.smtpService.sendEmail({
-          from: {
-            name: this.configService.getOrThrow('APP_NAME'),
-            address: this.configService.getOrThrow('DEFAULT_EMAIL_FROM'),
-          },
-          recipients: [{ name: user.full_name, address: user.email }],
-          subject: 'New Route Notification',
-          html: createRouteNotificationMail({
-            username: user.full_name,
-          }),
-          placeholderReplacements: {},
-        });
       }
 
       return { status: 201, message: 'Routes have been successfully created!' };
@@ -108,6 +82,7 @@ export class RouteService {
   }
 
   async getRouteFilters(startDate: Date, endDate: Date) {
+    // todo try catch statement
     const filters = await this.routeRepo
       .createQueryBuilder('route')
       .select(['DISTINCT user.full_name AS driver', 'COUNT(order.id) AS stopsCount', 'route.status AS status'])
@@ -183,6 +158,7 @@ export class RouteService {
       queryBuilder.orderBy(sortField === 'user_id.full_name' ? 'user.full_name' : `route.${sortField}`, sortOrder);
     }
 
+    // todo try catch statement
     const routes = await queryBuilder.getRawMany<RouteData>();
 
     if (!routes.length) {


### PR DESCRIPTION
## Describe your changes

- Fix assign orders to drivers logic ( There was cases when we have 2 drivers and some orders and previous algoritm returned  some orders for first driver and zero for second. Eventually user see an error.). Now each driver has at least one assigned order.

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [x] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [x] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
