### PR TITLE
Feat/get order luggages

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,6 +25,7 @@ import { OrdersModule } from './modules/orders/orders.module';
 import { RouteModule } from './modules/route/route.module';
 import { TicketsModule } from './modules/tickets/tickets.module';
 import { UserModule } from './modules/user/user.module';
+import { LuggagesModule } from './modules/luggages/luggages.module';
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { UserModule } from './modules/user/user.module';
     TicketsModule,
     CustomersModule,
     LuggageImagesModule,
+    LuggagesModule,
   ],
   controllers: [],
   providers: [],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,12 +20,12 @@ import { DatabaseModule } from './common/database/database.module';
 import { MailerModule } from './common/mailer/mailer.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { CustomersModule } from './modules/customers/customers.module';
+import { LuggagesModule } from './modules/luggages/luggages.module';
 import { ModuleExampleModule } from './modules/module-example/module-example.module';
 import { OrdersModule } from './modules/orders/orders.module';
 import { RouteModule } from './modules/route/route.module';
 import { TicketsModule } from './modules/tickets/tickets.module';
 import { UserModule } from './modules/user/user.module';
-import { LuggagesModule } from './modules/luggages/luggages.module';
 
 @Module({
   imports: [

--- a/src/common/database/entities/customer.entity.ts
+++ b/src/common/database/entities/customer.entity.ts
@@ -1,4 +1,6 @@
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+
+import { Order } from './order.entity';
 
 @Entity()
 export class Customer {
@@ -16,6 +18,9 @@ export class Customer {
 
   @Column({ nullable: false, default: false })
   is_passport_upploaded: boolean;
+
+  @OneToMany(() => Order, (order) => order.customer, { cascade: true })
+  orders: Order[];
 
   @CreateDateColumn({ type: 'timestamp' })
   createdAt: Date;

--- a/src/common/database/entities/order.entity.ts
+++ b/src/common/database/entities/order.entity.ts
@@ -5,6 +5,7 @@ import { Company } from './company.entity';
 import { Customer } from './customer.entity';
 import { Luggage } from './luggage.entity';
 import { Route } from './route.entity';
+import { User } from './user.entity';
 
 @Entity()
 export class Order {
@@ -38,13 +39,11 @@ export class Order {
   @Column({ type: 'text', nullable: true })
   failed_reason: string | null;
 
-  //
-  // @ManyToOne(() => Customer, (customer) => customer.id, { cascade: true, eager: true, nullable: false })
-  // @JoinColumn()
-  // customer: Customer;
-
   @ManyToOne(() => Customer, (customer) => customer.orders)
   customer: Customer;
+
+  @ManyToOne(() => User, (dispatcher) => dispatcher.orders)
+  dispatcher: User;
 
   @ManyToOne(() => Route, (route) => route.orders)
   route: Route | null;

--- a/src/common/database/entities/order.entity.ts
+++ b/src/common/database/entities/order.entity.ts
@@ -38,8 +38,12 @@ export class Order {
   @Column({ type: 'text', nullable: true })
   failed_reason: string | null;
 
-  @ManyToOne(() => Customer, (customer) => customer.id, { cascade: true, eager: true, nullable: false })
-  @JoinColumn()
+  //
+  // @ManyToOne(() => Customer, (customer) => customer.id, { cascade: true, eager: true, nullable: false })
+  // @JoinColumn()
+  // customer: Customer;
+
+  @ManyToOne(() => Customer, (customer) => customer.orders)
   customer: Customer;
 
   @ManyToOne(() => Route, (route) => route.orders)

--- a/src/common/database/entities/order.entity.ts
+++ b/src/common/database/entities/order.entity.ts
@@ -43,7 +43,7 @@ export class Order {
   customer: Customer;
 
   @ManyToOne(() => User, (dispatcher) => dispatcher.orders)
-  dispatcher: User;
+  dispatcher: User | null;
 
   @ManyToOne(() => Route, (route) => route.orders)
   route: Route | null;

--- a/src/common/database/entities/user.entity.ts
+++ b/src/common/database/entities/user.entity.ts
@@ -1,8 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Roles } from 'common/enums/enums';
-import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
 
 import { Company } from './company.entity';
+import { Order } from './order.entity';
 
 @Entity()
 export class User {
@@ -38,6 +39,9 @@ export class User {
   @JoinColumn()
   @ApiProperty({ example: Company, description: 'user company' })
   company_id: Company;
+
+  @OneToMany(() => Order, (order) => order.dispatcher, { cascade: true })
+  orders: Order[];
 
   @CreateDateColumn({ type: 'timestamp' })
   @ApiProperty({ example: new Date(), description: 'user created_at' })

--- a/src/common/enums/enums.ts
+++ b/src/common/enums/enums.ts
@@ -18,6 +18,12 @@ export enum OrderStatuses {
   AT_RISK = 'At Risk',
   UPCOMING = 'Upcoming',
   EMPTY_STATUS = '',
+  CUSTOMER_INFORMED = 'Customer Informed',
+  TRANSPORTER_LOCKED = 'Transporter Locked',
+  IDENTITY_VERIFIED = 'Identity Verified',
+  BOARDING_PASS_VERIFIED = 'Boarding pass verified',
+  BAGGAGE_CONFIRMED = 'Baggage confirmed',
+  CUSTOMER_CONFIRMED = 'Customer confirmed',
 }
 export enum Roles {
   DRIVER = 'driver',

--- a/src/common/enums/enums.ts
+++ b/src/common/enums/enums.ts
@@ -17,6 +17,7 @@ export enum OrderStatuses {
   NOT_ARRIVED = 'Not arrived',
   AT_RISK = 'At Risk',
   UPCOMING = 'Upcoming',
+  EMPTY_STATUS = '',
 }
 export enum Roles {
   DRIVER = 'driver',

--- a/src/common/enums/enums.ts
+++ b/src/common/enums/enums.ts
@@ -24,6 +24,9 @@ export enum OrderStatuses {
   BOARDING_PASS_VERIFIED = 'Boarding pass verified',
   BAGGAGE_CONFIRMED = 'Baggage confirmed',
   CUSTOMER_CONFIRMED = 'Customer confirmed',
+  BAGGAGE_RECORDED = 'Baggage recorded',
+  BAGGAGE_COVERED = 'Baggage covered',
+  LOADED_INTO_VEHICLE = 'Loaded into vehicle',
 }
 export enum Roles {
   DRIVER = 'driver',

--- a/src/modules/customers/customers.controller.ts
+++ b/src/modules/customers/customers.controller.ts
@@ -25,14 +25,14 @@ export class CustomersController {
     return this.customersService.verifyTicket(id, orderId);
   }
 
-  @Get(':id')
+  @Get('')
   @ApiOperation({ summary: 'Find a customer by ID' })
   @ApiParam({
     name: 'id',
     type: Number,
     description: 'The ID of the customer to retrieve',
   })
-  async findOne(@Param('id', ParseIntPipe) id: number): Promise<Customer> {
-    return this.customersService.findOne(id);
+  async findOne(@Query('orderId', ParseIntPipe) orderId: number): Promise<Customer> {
+    return this.customersService.findOne(orderId);
   }
 }

--- a/src/modules/customers/customers.controller.ts
+++ b/src/modules/customers/customers.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
-import { ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Customer } from 'common/database/entities/customer.entity';
 
 import { CustomersService } from './customers.service';
@@ -31,6 +31,11 @@ export class CustomersController {
     name: 'id',
     type: Number,
     description: 'The ID of the customer to retrieve',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Successfully retrieved customer',
+    type: Customer,
   })
   async findOne(@Query('orderId', ParseIntPipe) orderId: number): Promise<Customer> {
     return this.customersService.findOne(orderId);

--- a/src/modules/customers/customers.service.ts
+++ b/src/modules/customers/customers.service.ts
@@ -13,9 +13,9 @@ export class CustomersService {
     private readonly orderRepo: Repository<Order>,
   ) {}
 
-  async findOne(id: number): Promise<Customer> {
+  async findOne(orderId: number): Promise<Customer> {
     try {
-      return await this.customerRepo.findOneOrFail({ where: { id } });
+      return await this.customerRepo.findOneOrFail({ where: { orders: { id: orderId } } });
     } catch (error) {
       throw new NotFoundException('Customer not found');
     }

--- a/src/modules/customers/customers.service.ts
+++ b/src/modules/customers/customers.service.ts
@@ -23,7 +23,7 @@ export class CustomersService {
 
   async verifyTicket(customerId: number, orderId: number): Promise<boolean> {
     try {
-      const order = await this.orderRepo.findOneOrFail({ where: { id: orderId } });
+      const order = await this.orderRepo.findOneOrFail({ where: { id: orderId }, relations: ['customer'] });
 
       return order.customer.id === customerId;
     } catch (error) {

--- a/src/modules/luggages/luggages.controller.ts
+++ b/src/modules/luggages/luggages.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, ParseIntPipe, Query } from '@nestjs/common';
+
+import { LuggagesService } from './luggages.service';
+
+@Controller('luggages')
+export class LuggagesController {
+  constructor(private readonly luggagesService: LuggagesService) {}
+
+  @Get('count-in-order')
+  findAll(@Query('orderId', ParseIntPipe) orderId: number): Promise<{ countOfLuggages: number }> {
+    return this.luggagesService.getCountOfLuggages(orderId);
+  }
+}

--- a/src/modules/luggages/luggages.controller.ts
+++ b/src/modules/luggages/luggages.controller.ts
@@ -1,12 +1,25 @@
-import { Controller, Get, ParseIntPipe, Query } from '@nestjs/common';
+import { Controller, Get, ParseIntPipe, Query, SetMetadata, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Roles } from 'common/enums/enums';
+import { RolesGuard } from 'common/guards/roles.guard';
 
 import { LuggagesService } from './luggages.service';
 
 @Controller('luggages')
+@ApiTags('Luggages')
 export class LuggagesController {
   constructor(private readonly luggagesService: LuggagesService) {}
 
   @Get('count-in-order')
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.DRIVER])
+  @ApiQuery({
+    name: 'orderId',
+    type: Number,
+    description: 'The ID of the order associated with the luggages',
+  })
+  @ApiOperation({ summary: 'Get count of luggages for specific order' })
+  @ApiResponse({ status: 200, description: 'Get count of luggages request success', example: { countOfLuggages: 8 } })
   findAll(@Query('orderId', ParseIntPipe) orderId: number): Promise<{ countOfLuggages: number }> {
     return this.luggagesService.getCountOfLuggages(orderId);
   }

--- a/src/modules/luggages/luggages.controller.ts
+++ b/src/modules/luggages/luggages.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, ParseIntPipe, Query, SetMetadata, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Luggage } from 'common/database/entities/luggage.entity';
 import { Roles } from 'common/enums/enums';
 import { RolesGuard } from 'common/guards/roles.guard';
 
@@ -10,7 +11,7 @@ import { LuggagesService } from './luggages.service';
 export class LuggagesController {
   constructor(private readonly luggagesService: LuggagesService) {}
 
-  @Get('count-in-order')
+  @Get('for-weight-calculation')
   @UseGuards(RolesGuard)
   @SetMetadata('roles', [Roles.DRIVER])
   @ApiQuery({
@@ -19,8 +20,31 @@ export class LuggagesController {
     description: 'The ID of the order associated with the luggages',
   })
   @ApiOperation({ summary: 'Get count of luggages for specific order' })
-  @ApiResponse({ status: 200, description: 'Get count of luggages request success', example: { countOfLuggages: 8 } })
-  findAll(@Query('orderId', ParseIntPipe) orderId: number): Promise<{ countOfLuggages: number }> {
+  @ApiResponse({
+    status: 200,
+    description: 'Get count of luggages request success',
+    example: [
+      {
+        id: 6,
+        luggage_type: 'small',
+        luggage_weight: 5,
+        luggage_description: '',
+      },
+      {
+        id: 7,
+        luggage_type: 'middle',
+        luggage_weight: 7,
+        luggage_description: '',
+      },
+      {
+        id: 8,
+        luggage_type: 'big',
+        luggage_weight: 23,
+        luggage_description: '',
+      },
+    ],
+  })
+  findAll(@Query('orderId', ParseIntPipe) orderId: number): Promise<Luggage[]> {
     return this.luggagesService.getCountOfLuggages(orderId);
   }
 }

--- a/src/modules/luggages/luggages.module.ts
+++ b/src/modules/luggages/luggages.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Luggage } from 'common/database/entities/luggage.entity';
+
+import { LuggagesController } from './luggages.controller';
+import { LuggagesService } from './luggages.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Luggage])],
+  controllers: [LuggagesController],
+  providers: [LuggagesService],
+})
+export class LuggagesModule {}

--- a/src/modules/luggages/luggages.service.ts
+++ b/src/modules/luggages/luggages.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Luggage } from 'common/database/entities/luggage.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class LuggagesService {
+  constructor(
+    @InjectRepository(Luggage)
+    private readonly luggageRepository: Repository<Luggage>,
+  ) {}
+
+  async getCountOfLuggages(orderId: number): Promise<{ countOfLuggages: number }> {
+    try {
+      const countOfLuggages = await this.luggageRepository.count({ where: { order: { id: orderId } } });
+
+      return { countOfLuggages };
+    } catch (error) {
+      throw new NotFoundException('Cant find such luggages');
+    }
+  }
+}

--- a/src/modules/luggages/luggages.service.ts
+++ b/src/modules/luggages/luggages.service.ts
@@ -10,11 +10,13 @@ export class LuggagesService {
     private readonly luggageRepository: Repository<Luggage>,
   ) {}
 
-  async getCountOfLuggages(orderId: number): Promise<{ countOfLuggages: number }> {
+  async getCountOfLuggages(orderId: number): Promise<Luggage[]> {
     try {
-      const countOfLuggages = await this.luggageRepository.count({ where: { order: { id: orderId } } });
-
-      return { countOfLuggages };
+      return await this.luggageRepository
+        .createQueryBuilder('luggage')
+        .select(['luggage.id', 'luggage.luggage_type', 'luggage.luggage_weight', 'luggage.luggage_description'])
+        .where('luggage.order.id = :orderId', { orderId })
+        .getMany();
     } catch (error) {
       throw new NotFoundException('Cant find such luggages');
     }

--- a/src/modules/orders/interfaces/orderDetails.ts
+++ b/src/modules/orders/interfaces/orderDetails.ts
@@ -1,4 +1,4 @@
-import { LuggageTypes } from 'common/enums/enums';
+import { LuggageTypes, OrderStatuses } from 'common/enums/enums';
 
 interface TransformedLuggage {
   luggageType: LuggageTypes;
@@ -7,6 +7,7 @@ interface TransformedLuggage {
 
 export interface OrderDetails {
   collectionDate: Date;
+  status: OrderStatuses;
   collectionTimeStart: Date;
   collectionTimeEnd: Date;
   collectionAddress: string;

--- a/src/modules/orders/interfaces/orderDetails.ts
+++ b/src/modules/orders/interfaces/orderDetails.ts
@@ -1,0 +1,20 @@
+import { LuggageTypes } from 'common/enums/enums';
+
+interface TransformedLuggage {
+  luggageType: LuggageTypes;
+  luggageWeight: number;
+}
+
+export interface OrderDetails {
+  collectionDate: Date;
+  collectionTimeStart: Date;
+  collectionTimeEnd: Date;
+  collectionAddress: string;
+  airportName: string;
+  flightId: string;
+  customerFullName: string;
+  customerPhoneNumber: string;
+  dispatcherFullName: string;
+  dispatcherPhoneNumber: string;
+  luggages: TransformedLuggage[];
+}

--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -44,49 +44,6 @@ export class OrdersController {
     return this.ordersService.findAll({ ...queryParams, isNew: stringToBoolean(queryParams.isNew) });
   }
 
-  @Get(':id')
-  @UseGuards(RolesGuard)
-  @SetMetadata('roles', [Roles.DRIVER])
-  @ApiOperation({ summary: 'Get detailed information about specific Order' })
-  @ApiParam({ name: 'id', description: 'Order id', example: 23 })
-  @ApiResponse({
-    status: 200,
-    description: 'Get order details',
-    example: {
-      collectionDate: '2024-12-31T00:00:00.000Z',
-      collectionTimeStart: '2024-12-31T09:05:00.000Z',
-      collectionTimeEnd: '2024-12-31T09:05:00.000Z',
-      collectionAddress: '202 Elm Ave, Columbus, OH',
-      airportName: 'John F. Kennedy International Airport',
-      flightId: 'Yss234jJi',
-      customerFullName: 'Charlie Brown',
-      customerPhoneNumber: '+380-63-345-6789',
-      dispatcherFullName: 'another driver',
-      dispatcherPhoneNumber: '+380559482317',
-      luggages: [
-        {
-          luggageType: 'big',
-          luggageWeight: 15,
-        },
-        {
-          luggageType: 'big',
-          luggageWeight: 15,
-        },
-        {
-          luggageType: 'middle',
-          luggageWeight: 7,
-        },
-        {
-          luggageType: 'middle',
-          luggageWeight: 7,
-        },
-      ],
-    },
-  })
-  async getOrderData(@Param('id', ParseIntPipe) id: number): Promise<OrderDetails> {
-    return this.ordersService.getOne(id);
-  }
-
   @Get('boarding-pass/:id')
   @UseGuards(RolesGuard)
   @SetMetadata('roles', [Roles.DRIVER])
@@ -158,7 +115,10 @@ export class OrdersController {
     },
   })
   @ApiResponse({ status: 500, type: FailedResponse })
-  async findOrdersByDriverAndDate(@Query() { date, driverId }: { date: Date; driverId: number }): Promise<OrderWithRouteAndCustomer[]> {
+  async findOrdersByDriverAndDate(
+    @Query('date') date: string,
+    @Query('driverId', ParseIntPipe) driverId: number,
+  ): Promise<OrderWithRouteAndCustomer[]> {
     const parsedDate = new Date(date);
     return this.ordersService.getOrdersByDriverAndDate(driverId, parsedDate);
   }
@@ -182,5 +142,48 @@ export class OrdersController {
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async setFailedReason(@Body('orderId') orderId: number, @Body('reason') reason: string): Promise<Order> {
     return this.ordersService.setFailedReason(orderId, reason);
+  }
+
+  @Get(':id')
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.DRIVER])
+  @ApiOperation({ summary: 'Get detailed information about specific Order' })
+  @ApiParam({ name: 'id', description: 'Order id', example: 23 })
+  @ApiResponse({
+    status: 200,
+    description: 'Get order details',
+    example: {
+      collectionDate: '2024-12-31T00:00:00.000Z',
+      collectionTimeStart: '2024-12-31T09:05:00.000Z',
+      collectionTimeEnd: '2024-12-31T09:05:00.000Z',
+      collectionAddress: '202 Elm Ave, Columbus, OH',
+      airportName: 'John F. Kennedy International Airport',
+      flightId: 'Yss234jJi',
+      customerFullName: 'Charlie Brown',
+      customerPhoneNumber: '+380-63-345-6789',
+      dispatcherFullName: 'another driver',
+      dispatcherPhoneNumber: '+380559482317',
+      luggages: [
+        {
+          luggageType: 'big',
+          luggageWeight: 15,
+        },
+        {
+          luggageType: 'big',
+          luggageWeight: 15,
+        },
+        {
+          luggageType: 'middle',
+          luggageWeight: 7,
+        },
+        {
+          luggageType: 'middle',
+          luggageWeight: 7,
+        },
+      ],
+    },
+  })
+  async getOrderData(@Param('id', ParseIntPipe) id: number): Promise<OrderDetails> {
+    return this.ordersService.getOne(id);
   }
 }

--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -12,6 +12,7 @@ import { stringToBoolean } from 'common/utils/stringToBoolean';
 import { TransformedOrder } from 'common/utils/transformOrderObject';
 
 import { OrdersResponse } from './dto/response.dto';
+import { OrderDetails } from './interfaces/orderDetails';
 import { OrdersService } from './orders.service';
 import { OrderQueryParams } from './types';
 
@@ -48,8 +49,41 @@ export class OrdersController {
   @SetMetadata('roles', [Roles.DRIVER])
   @ApiOperation({ summary: 'Get detailed information about specific Order' })
   @ApiParam({ name: 'id', description: 'Order id', example: 23 })
-  @ApiResponse({ status: 200, description: 'Get order details' })
-  async getOrderData(@Param('id', ParseIntPipe) id: number): Promise<Order> {
+  @ApiResponse({
+    status: 200,
+    description: 'Get order details',
+    example: {
+      collectionDate: '2024-12-31T00:00:00.000Z',
+      collectionTimeStart: '2024-12-31T09:05:00.000Z',
+      collectionTimeEnd: '2024-12-31T09:05:00.000Z',
+      collectionAddress: '202 Elm Ave, Columbus, OH',
+      airportName: 'John F. Kennedy International Airport',
+      flightId: 'Yss234jJi',
+      customerFullName: 'Charlie Brown',
+      customerPhoneNumber: '+380-63-345-6789',
+      dispatcherFullName: 'another driver',
+      dispatcherPhoneNumber: '+380559482317',
+      luggages: [
+        {
+          luggageType: 'big',
+          luggageWeight: 15,
+        },
+        {
+          luggageType: 'big',
+          luggageWeight: 15,
+        },
+        {
+          luggageType: 'middle',
+          luggageWeight: 7,
+        },
+        {
+          luggageType: 'middle',
+          luggageWeight: 7,
+        },
+      ],
+    },
+  })
+  async getOrderData(@Param('id', ParseIntPipe) id: number): Promise<OrderDetails> {
     return this.ordersService.getOne(id);
   }
 

--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -1,9 +1,9 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Post, Query, SetMetadata, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query, SetMetadata, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Order } from 'common/database/entities/order.entity';
 import { User } from 'common/database/entities/user.entity';
 import { ParseAssignOrdersJson } from 'common/decorators/parseJsonDecorator';
-import { Roles } from 'common/enums/enums';
+import { OrderStatuses, Roles } from 'common/enums/enums';
 import { RolesGuard } from 'common/guards/roles.guard';
 import { AssignedOrdersResponse } from 'common/types/assignedOrdersResponse';
 import { FailedResponse } from 'common/types/failed-response.dto';
@@ -142,6 +142,13 @@ export class OrdersController {
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async setFailedReason(@Body('orderId') orderId: number, @Body('reason') reason: string): Promise<Order> {
     return this.ordersService.setFailedReason(orderId, reason);
+  }
+
+  @Patch(':id')
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.DRIVER])
+  async changeOrderStatus(@Param('id', ParseIntPipe) id: number, @Body('status') status: OrderStatuses): Promise<boolean> {
+    return this.ordersService.updateOrderStatus(id, status);
   }
 
   @Get(':id')

--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -43,6 +43,16 @@ export class OrdersController {
     return this.ordersService.findAll({ ...queryParams, isNew: stringToBoolean(queryParams.isNew) });
   }
 
+  @Get(':id')
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.DRIVER])
+  @ApiOperation({ summary: 'Get detailed information about specific Order' })
+  @ApiParam({ name: 'id', description: 'Order id', example: 23 })
+  @ApiResponse({ status: 200, description: 'Get order details' })
+  async getOrderData(@Param('id', ParseIntPipe) id: number): Promise<Order> {
+    return this.ordersService.getOne(id);
+  }
+
   @Get('boarding-pass/:id')
   @UseGuards(RolesGuard)
   @SetMetadata('roles', [Roles.DRIVER])

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -359,6 +359,7 @@ export class OrdersService {
       const order = await this.orderRepository.findOneOrFail({ where: { id: orderId } });
 
       order.failed_reason = reason;
+      order.status = OrderStatuses.FAILED;
 
       return await this.orderRepository.save(order);
     } catch (error) {

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -137,9 +137,17 @@ export class OrdersService {
     }
   }
 
+  async getOne(id: number): Promise<Order> {
+    try {
+      return await this.orderRepository.findOneOrFail({ where: { id }, relations: ['dispatcher'] });
+    } catch (error) {
+      throw new NotFoundException('');
+    }
+  }
+
   async getOneForBoardingPass(id: number): Promise<TransformedOrder> {
     try {
-      const order = await this.orderRepository.findOneOrFail({ where: { id } });
+      const order = await this.orderRepository.findOneOrFail({ where: { id }, relations: ['customer'] });
 
       return tranformOrderObject(order);
     } catch (error) {

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -50,7 +50,7 @@ export class OrdersService {
     const findSettings: FindManyOptions<Order> = {
       skip: (page - 1) * ORDER_PAGE_LENGTH,
       take: ORDER_PAGE_LENGTH,
-      relations: ['luggages', 'route'],
+      relations: ['luggages', 'route', 'customer'],
       where: search
         ? [
             {

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -10,6 +10,7 @@ import { OrderWithRouteAndCustomer } from 'common/types/interfaces';
 import { tranformOrderObject, TransformedOrder } from 'common/utils/transformOrderObject';
 import { FindManyOptions, IsNull, Like, Between, Not, Repository, EntityNotFoundError } from 'typeorm';
 
+import { OrderDetails } from './interfaces/orderDetails';
 import { OrderServiceParams } from './types';
 
 @Injectable()
@@ -137,9 +138,9 @@ export class OrdersService {
     }
   }
 
-  async getOne(id: number): Promise<Order> {
+  async getOne(id: number): Promise<OrderDetails> {
     try {
-      const order: Order | undefined = await this.orderRepository
+      const order: OrderDetails | undefined = await this.orderRepository
         .createQueryBuilder('order')
         .leftJoin('order.dispatcher', 'dispatcher')
         .leftJoin('order.customer', 'customer')

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -139,7 +139,38 @@ export class OrdersService {
 
   async getOne(id: number): Promise<Order> {
     try {
-      return await this.orderRepository.findOneOrFail({ where: { id }, relations: ['dispatcher'] });
+      const order: Order | undefined = await this.orderRepository
+        .createQueryBuilder('order')
+        .leftJoin('order.dispatcher', 'dispatcher')
+        .leftJoin('order.customer', 'customer')
+        .leftJoin('order.luggages', 'luggages')
+        .select([
+          'order.collection_date AS collectionDate',
+          'order.collection_time_start AS collectionTimeStart',
+          'order.collection_time_end AS collectionTimeEnd',
+          'order.collection_address AS collectionAddress',
+          'order.airport_name AS airportName',
+          'order.flight_id AS flightId',
+          'customer.full_name AS customerFullName',
+          'customer.phone_number AS customerPhoneNumber',
+          'dispatcher.full_name AS dispatcherFullName',
+          'dispatcher.phone_number AS dispatcherPhoneNumber',
+          `JSON_ARRAYAGG(
+            JSON_OBJECT(
+              'luggageType', luggages.luggage_type,
+              'luggageWeight', luggages.luggage_weight
+            )
+          ) AS luggages`,
+        ])
+        .where('order.id = :id', { id })
+        .groupBy('order.id, customer.id, dispatcher.id')
+        .getRawOne();
+
+      if (typeof order === 'undefined') {
+        throw new Error();
+      }
+
+      return order;
     } catch (error) {
       throw new NotFoundException('');
     }

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -313,6 +313,16 @@ export class OrdersService {
     }
   }
 
+  async updateOrderStatus(id: number, status: OrderStatuses): Promise<boolean> {
+    try {
+      await this.orderRepository.update(id, { status });
+
+      return true;
+    } catch (error) {
+      throw new NotFoundException('');
+    }
+  }
+
   async getOrdersByDriverAndDate(driverId: number, date: Date): Promise<OrderWithRouteAndCustomer[]> {
     const startOfDay = new Date(date);
     startOfDay.setHours(0, 0, 0, 0);

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -147,6 +147,7 @@ export class OrdersService {
         .leftJoin('order.luggages', 'luggages')
         .select([
           'order.collection_date AS collectionDate',
+          'order.status AS status',
           'order.collection_time_start AS collectionTimeStart',
           'order.collection_time_end AS collectionTimeEnd',
           'order.collection_address AS collectionAddress',

--- a/src/modules/route/dto/create-route.dto.ts
+++ b/src/modules/route/dto/create-route.dto.ts
@@ -1,4 +1,5 @@
 import { Company } from 'common/database/entities/company.entity';
+import { Order } from 'common/database/entities/order.entity';
 import { User } from 'common/database/entities/user.entity';
 import { RouteStatuses } from 'common/enums/enums';
 
@@ -9,4 +10,5 @@ export class CreateRouteDto {
   status: RouteStatuses;
   user_id: User;
   company_id: Company;
+  orders: Order[];
 }

--- a/src/modules/route/route.module.ts
+++ b/src/modules/route/route.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Company } from 'common/database/entities/company.entity';
+import { Notification } from 'common/database/entities/notification.entity';
 import { Order } from 'common/database/entities/order.entity';
 import { Route } from 'common/database/entities/route.entity';
 import { User } from 'common/database/entities/user.entity';
@@ -10,7 +11,7 @@ import { RouteController } from './route.controller';
 import { RouteService } from './route.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Route, User, Company, Order])],
+  imports: [TypeOrmModule.forFeature([Route, User, Company, Order, Notification])],
   controllers: [RouteController],
   providers: [RouteService, MailerService],
 })

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -6,7 +6,7 @@ import { ROUTE_START_POINT } from 'common/constants/strings';
 import { Order } from 'common/database/entities/order.entity';
 import { Route } from 'common/database/entities/route.entity';
 import { User } from 'common/database/entities/user.entity';
-import { SortOrder } from 'common/enums/enums';
+import { OrderStatuses, RouteStatuses, SortOrder } from 'common/enums/enums';
 import { SuccessResponse } from 'common/types/response-success.dto';
 import { RouteInform } from 'common/types/routeInformResponse';
 import { sortOrdersByRouteObject, transformRouteObject } from 'common/utils/transformRouteObject';
@@ -31,7 +31,39 @@ export class RouteService {
 
   async create(createRouteDto: CreateRouteDto[]): Promise<SuccessResponse> {
     try {
-      const routes = createRouteDto.map((routeDto) => new Route(routeDto));
+      const routes = createRouteDto.map((routeDto) => {
+        const hasAtRiskOrders = routeDto.orders.some((currentOrder) => {
+          const countOfTheSame = routeDto.orders.reduce((count, order) => {
+            if (currentOrder.collection_time_start === order.collection_time_start) {
+              return count + 1;
+            }
+            return count;
+          }, 0);
+
+          return countOfTheSame > 1;
+        });
+
+        const routeStatus = hasAtRiskOrders ? RouteStatuses.AT_RISK : RouteStatuses.UPCOMING;
+
+        return new Route({
+          ...routeDto,
+          status: routeStatus,
+          orders: routeDto.orders.map((currentOrder) => {
+            const countOfTheSame = routeDto.orders.reduce((count, order) => {
+              if (currentOrder.collection_time_start === order.collection_time_start) {
+                return count + 1;
+              }
+              return count;
+            }, 0);
+
+            if (countOfTheSame > 1) {
+              return new Order({ ...currentOrder, status: OrderStatuses.AT_RISK });
+            }
+
+            return new Order({ ...currentOrder, status: OrderStatuses.UPCOMING });
+          }),
+        });
+      });
 
       for (const route of routes) {
         await this.routeRepo.save(route);

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -309,15 +309,24 @@ export class RouteService {
 
   async deleteRoute(routeId: number): Promise<SuccessResponse> {
     try {
-      const deletedRoute: DeleteResult = await this.routeRepo.softDelete(routeId);
+      const route = await this.routeRepo.findOne({ where: { id: routeId }, relations: ['orders'] });
 
-      if (deletedRoute.affected !== undefined && deletedRoute.affected !== null) {
-        if (deletedRoute.affected < 1) throw new Error();
-      } else {
-        throw new Error();
+      if (!route) {
+        throw new NotFoundException('There is no such route');
       }
 
-      return { status: 200, message: 'route deleted successfully' };
+      const orderIds = route.orders.map((order) => order.id);
+      if (orderIds.length > 0) {
+        await this.orderRepo.update(orderIds, { route: null, status: OrderStatuses.EMPTY_STATUS });
+      }
+
+      const deletedRoute: DeleteResult = await this.routeRepo.softDelete(routeId);
+
+      if (!deletedRoute.affected || deletedRoute.affected < 1) {
+        throw new NotFoundException('There is no such route');
+      }
+
+      return { status: 200, message: 'Route deleted successfully' };
     } catch (error) {
       throw new NotFoundException('There is no such route');
     }

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -246,9 +246,7 @@ export class RouteService {
         throw new BadRequestException();
       }
 
-      const order = await this.orderRepo.findOneOrFail({ where: { id: orderId } });
-      order.route = null;
-      await this.entityManager.save(order);
+      await this.orderRepo.update(orderId, { route: null, dispatcher: null, status: OrderStatuses.EMPTY_STATUS });
 
       const updatedRoute = await this.routeRepo.findOneOrFail({ where: { id: routeId }, relations: ['orders'] });
 
@@ -258,12 +256,39 @@ export class RouteService {
 
       await this.calculateRouteDistance([ROUTE_START_POINT, ...cities]).then(async (result) => {
         if (result) {
-          updatedRoute.distance = Math.ceil(result.distance / 1000);
-          await this.entityManager.save(updatedRoute);
+          const newDistance = Math.ceil(result.distance / 1000);
+          updatedRoute.distance = newDistance;
+          await this.routeRepo.update(routeId, { distance: newDistance });
         }
       });
 
-      return await this.getOne(routeId);
+      let hasOrdersWithTheSameTime = false;
+
+      for (const currentOrder of updatedRoute.orders) {
+        const sameOrders = updatedRoute.orders.reduce((amount, order) => {
+          if (currentOrder.collection_time_start === order.collection_time_start) {
+            return amount + 1;
+          }
+          return amount;
+        }, 0);
+
+        if (sameOrders > 1) {
+          hasOrdersWithTheSameTime = true;
+        }
+
+        if (!hasOrdersWithTheSameTime && currentOrder.status === OrderStatuses.AT_RISK) {
+          await this.orderRepo.update(currentOrder.id, { status: OrderStatuses.UPCOMING });
+
+          currentOrder.status = OrderStatuses.UPCOMING;
+        }
+      }
+
+      if (!hasOrdersWithTheSameTime && updatedRoute.status === RouteStatuses.AT_RISK) {
+        updatedRoute.status = RouteStatuses.UPCOMING;
+        await this.routeRepo.update(routeId, { status: RouteStatuses.UPCOMING });
+      }
+
+      return transformRouteObject(updatedRoute);
     } catch (error) {
       throw new NotFoundException('There is no such order');
     }

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -3,10 +3,11 @@ import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import axios from 'axios';
 import { ROUTE_START_POINT } from 'common/constants/strings';
+import { Notification } from 'common/database/entities/notification.entity';
 import { Order } from 'common/database/entities/order.entity';
 import { Route } from 'common/database/entities/route.entity';
 import { User } from 'common/database/entities/user.entity';
-import { OrderStatuses, RouteStatuses, SortOrder } from 'common/enums/enums';
+import { NotificationTypes, OrderStatuses, RouteStatuses, SortOrder } from 'common/enums/enums';
 import { SuccessResponse } from 'common/types/response-success.dto';
 import { RouteInform } from 'common/types/routeInformResponse';
 import { sortOrdersByRouteObject, transformRouteObject } from 'common/utils/transformRouteObject';
@@ -24,6 +25,8 @@ export class RouteService {
     private readonly routeRepo: Repository<Route>,
     @InjectRepository(Order)
     private readonly orderRepo: Repository<Order>,
+    @InjectRepository(Notification)
+    private readonly notificationRepo: Repository<Notification>,
     @InjectRepository(User)
     private readonly entityManager: EntityManager,
     private readonly configService: ConfigService,
@@ -31,6 +34,7 @@ export class RouteService {
 
   async create(createRouteDto: CreateRouteDto[]): Promise<SuccessResponse> {
     try {
+      const notifications: Notification[] = [];
       const routes = createRouteDto.map((routeDto) => {
         const hasAtRiskOrders = routeDto.orders.some((currentOrder) => {
           const countOfTheSame = routeDto.orders.reduce((count, order) => {
@@ -66,7 +70,23 @@ export class RouteService {
       });
 
       for (const route of routes) {
-        await this.routeRepo.save(route);
+        const savedRoute = await this.routeRepo.save(route);
+        const { user_id: driver } = savedRoute;
+
+        notifications.push(
+          new Notification({
+            type: NotificationTypes.ROUTE,
+            is_readed: false,
+            link_text: `${savedRoute.id}`,
+            link_href: ``,
+            message: 'You have received a new route',
+            user_id: driver,
+          }),
+        );
+      }
+
+      if (notifications.length > 0) {
+        await this.notificationRepo.save(notifications);
       }
 
       return { status: 201, message: 'Routes have been successfully created!' };


### PR DESCRIPTION
## Describe your changes

- Status management
- Get OrderDetails endpoint

## Issue ticket code (and/or) and link

- [Status management task](https://codecraftersintership.atlassian.net/browse/SCRUM-208?atlOrigin=eyJpIjoiM2M3ZGFiY2U4MTlmNDI5YWIyMTZjODFjNmJiNmQxZTEiLCJwIjoiaiJ9)
- [Connect all pages task](https://codecraftersintership.atlassian.net/browse/SCRUM-203?atlOrigin=eyJpIjoiMWQ1OTIyNDRkMTI2NGY5MWFlYmFkMTFiYTMwNjFiMjEiLCJwIjoiaiJ9)

## Changed DB (createdAt && updatedAt is not on the bottom because it's default dbEaver settings)
![image](https://github.com/user-attachments/assets/224012a0-e1ed-4661-92f6-30acd61c1b6a)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [x] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [x] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
