### PR TITLE
feat: added sorting functionality for orders in route object

### DIFF
--- a/src/common/utils/transformRouteObject.ts
+++ b/src/common/utils/transformRouteObject.ts
@@ -23,3 +23,11 @@ export const transformRouteObject = (routeObject: Route): RouteInform => {
     })),
   };
 };
+
+export const sortOrdersByRouteObject = (routeInformObject: RouteInform): RouteInform => {
+  const sortedOrders = routeInformObject.orders.sort((a, b) => a.collection_time_start.getHours() - b.collection_time_start.getHours());
+  return {
+    ...routeInformObject,
+    orders: sortedOrders,
+  };
+};

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -9,7 +9,7 @@ import { User } from 'common/database/entities/user.entity';
 import { SortOrder } from 'common/enums/enums';
 import { SuccessResponse } from 'common/types/response-success.dto';
 import { RouteInform } from 'common/types/routeInformResponse';
-import { transformRouteObject } from 'common/utils/transformRouteObject';
+import { sortOrdersByRouteObject, transformRouteObject } from 'common/utils/transformRouteObject';
 import { DeleteResult, EntityManager, EntityNotFoundError, Repository, Between } from 'typeorm';
 
 import { CreateRouteDto } from './dto/create-route.dto';
@@ -69,7 +69,9 @@ export class RouteService {
         relations: ['orders'],
       });
 
-      return transformRouteObject(route);
+      const routeInformObject = transformRouteObject(route);
+
+      return sortOrdersByRouteObject(routeInformObject);
     } catch (error) {
       if (error instanceof EntityNotFoundError) {
         throw new NotFoundException('There is no such route');


### PR DESCRIPTION
## Describe your changes

- I added sorting functionality for orders in route object instead of sorting on FE side.

## Issue ticket code (and/or) and link

- [SCRUM-202](https://codecraftersintership.atlassian.net/browse/SCRUM-202)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [ ] use @`@index` decorator for frequently requested data
- [ ] use transactions if there is a call chain that mutates data in different tables
- [ ] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [ ] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [ ] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
