### PR TITLE
+ Create: lock smartLock endpoint

### DIFF
--- a/src/common/database/entities/order.entity.ts
+++ b/src/common/database/entities/order.entity.ts
@@ -12,6 +12,12 @@ export class Order {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column({ default: false })
+  is_order_locked: boolean;
+
+  @Column()
+  lock_number: string;
+
   @Column({ nullable: false })
   collection_date: Date;
 

--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query, SetMetadata, UseGuards } from '@nestjs/common';
-import { ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Order } from 'common/database/entities/order.entity';
 import { User } from 'common/database/entities/user.entity';
 import { ParseAssignOrdersJson } from 'common/decorators/parseJsonDecorator';
@@ -142,6 +142,52 @@ export class OrdersController {
   @ApiResponse({ status: 500, description: 'Internal server error' })
   async setFailedReason(@Body('orderId') orderId: number, @Body('reason') reason: string): Promise<Order> {
     return this.ordersService.setFailedReason(orderId, reason);
+  }
+
+  @Patch('locking-baggage/:id')
+  @UseGuards(RolesGuard)
+  @SetMetadata('roles', [Roles.DRIVER])
+  @ApiOperation({
+    summary: 'Lock baggage',
+    description: 'Locks a baggage item by its ID and updates the lock number.',
+  })
+  @ApiParam({
+    name: 'id',
+    type: Number,
+    description: 'The ID of the baggage item to lock.',
+    required: true,
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        lockNumber: {
+          type: 'string',
+          description: 'The lock number to set for the baggage.',
+          example: '12345LOCK',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Baggage locked successfully.',
+    type: Boolean,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid ID or lock number provided.',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Baggage item not found.',
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Unexpected error while locking baggage.',
+  })
+  async lockBaggage(@Param('id', ParseIntPipe) id: number, @Body() { lockNumber }: { lockNumber: string }): Promise<boolean> {
+    return this.ordersService.lockBaggage(id, lockNumber);
   }
 
   @Patch(':id')

--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -164,7 +164,7 @@ export class OrdersController {
         lockNumber: {
           type: 'string',
           description: 'The lock number to set for the baggage.',
-          example: '12345LOCK',
+          example: '123456987456',
         },
       },
     },

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -179,6 +179,16 @@ export class OrdersService {
     }
   }
 
+  async lockBaggage(orderId: number, lockNumber: string): Promise<boolean> {
+    try {
+      await this.orderRepository.update(orderId, { lock_number: lockNumber, is_order_locked: true });
+
+      return true;
+    } catch (error) {
+      throw new NotFoundException();
+    }
+  }
+
   async getOneForBoardingPass(id: number): Promise<TransformedOrder> {
     try {
       const order = await this.orderRepository.findOneOrFail({ where: { id }, relations: ['customer'] });


### PR DESCRIPTION
## Describe your changes

- Create set smartLock code endpoint

## Issue ticket code (and/or) and link

- [Research barcode scaning](https://codecraftersintership.atlassian.net/browse/SCRUM-236?atlOrigin=eyJpIjoiMDcxMDJhMzc5OWY5NGYxMTk4OTI5Y2M2Y2YyNWM0NjEiLCJwIjoiaiJ9)

## Updated Order entity
![image](https://github.com/user-attachments/assets/b3c47617-ac39-432c-9c19-e9776b06c372)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [x] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [ ] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
