### PR TITLE
feat: add endpoint to fetch orders by route based on order ID

### DIFF
--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -262,4 +262,18 @@ export class OrdersController {
   async getOrderData(@Param('id', ParseIntPipe) id: number): Promise<OrderDetails> {
     return this.ordersService.getOne(id);
   }
+
+  @Get('route/:orderId')
+  @ApiOperation({ summary: 'Retrieve all orders for a specific route by order ID' })
+  @ApiParam({ name: 'orderId', description: 'ID of the order to find related route', example: 1 })
+  @ApiResponse({
+    status: 200,
+    description: 'List of orders associated with the route',
+    type: [Order],
+  })
+  @ApiResponse({ status: 404, description: 'Order or Route not found' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  async getOrdersByRoute(@Param('orderId', ParseIntPipe) orderId: number): Promise<Order[]> {
+    return this.ordersService.getOrdersByRoute(orderId);
+  }
 }

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -412,4 +412,27 @@ export class OrdersService {
         : null,
     }));
   }
+
+  async getOrdersByRoute(orderId: number): Promise<Order[]> {
+    try {
+      const order = await this.orderRepository.findOneOrFail({
+        where: { id: orderId },
+        relations: ['route'],
+      });
+
+      if (!order.route) {
+        throw new NotFoundException(`Order with ID ${orderId} does not belong to any route`);
+      }
+
+      return await this.orderRepository.find({
+        where: { route: { id: order.route.id } },
+      });
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) {
+        throw new NotFoundException(`Order with ID ${orderId} not found`);
+      }
+
+      throw new InternalServerErrorException('Error fetching orders for route');
+    }
+  }
 }


### PR DESCRIPTION
## Describe your changes

- Fetch array of orders by order id in specific route

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://codecraftersintership.atlassian.net/browse/SCRUM-263)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [x] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [x] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [ ] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
