### PR TITLE
fix: added changing of orders status related to the route

### DIFF
--- a/src/common/enums/enums.ts
+++ b/src/common/enums/enums.ts
@@ -17,6 +17,7 @@ export enum OrderStatuses {
   NOT_ARRIVED = 'Not arrived',
   AT_RISK = 'At Risk',
   UPCOMING = 'Upcoming',
+  ON_TIME = 'On Time',
   EMPTY_STATUS = '',
   CUSTOMER_INFORMED = 'Customer Informed',
   TRANSPORTER_LOCKED = 'Transporter Locked',

--- a/src/modules/route/route.service.ts
+++ b/src/modules/route/route.service.ts
@@ -11,7 +11,7 @@ import { NotificationTypes, OrderStatuses, RouteStatuses, SortOrder } from 'comm
 import { SuccessResponse } from 'common/types/response-success.dto';
 import { RouteInform } from 'common/types/routeInformResponse';
 import { sortOrdersByRouteObject, transformRouteObject } from 'common/utils/transformRouteObject';
-import { DeleteResult, EntityNotFoundError, Repository, Between } from 'typeorm';
+import { DeleteResult, EntityNotFoundError, Repository, Between, DataSource } from 'typeorm';
 
 import { CreateRouteDto } from './dto/create-route.dto';
 import { ErrorResponse } from './dto/error-response.dto';
@@ -29,6 +29,7 @@ export class RouteService {
     private readonly notificationRepo: Repository<Notification>,
     @InjectRepository(User)
     private readonly configService: ConfigService,
+    private readonly dataSource: DataSource,
   ) {}
 
   async create(createRouteDto: CreateRouteDto[]): Promise<SuccessResponse> {
@@ -322,17 +323,43 @@ export class RouteService {
   }
 
   async updateRouteStatus(routeId: number, updateRouteStatusDto: UpdateRouteStatusDto): Promise<RouteInform> {
-    try {
-      await this.routeRepo.findOneOrFail({ where: { id: routeId, user_id: { id: updateRouteStatusDto.driverId } } });
+    const queryRunner = this.dataSource.createQueryRunner();
 
-      await this.routeRepo.update(routeId, { status: updateRouteStatusDto.status });
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      const route = await this.routeRepo.findOneOrFail({
+        where: { id: routeId, user_id: { id: updateRouteStatusDto.driverId } },
+        relations: ['orders'],
+      });
+
+      route.status = updateRouteStatusDto.status;
+      await queryRunner.manager.save(route);
+
+      if (route.orders.length > 0) {
+        const updatedOrders = route.orders.map((order) => {
+          if (order.status === OrderStatuses.UPCOMING) {
+            order.status = OrderStatuses.ON_TIME;
+          }
+          return order;
+        });
+
+        await queryRunner.manager.save(updatedOrders);
+      }
+
+      await queryRunner.commitTransaction();
 
       return await this.getOne(routeId);
-    } catch (error) {
+    } catch (error: unknown) {
+      await queryRunner.rollbackTransaction();
+
       if (error instanceof EntityNotFoundError) {
         throw new NotFoundException('There is no such route');
       }
-      throw new InternalServerErrorException('Something went wrong');
+      throw new InternalServerErrorException(error);
+    } finally {
+      await queryRunner.release();
     }
   }
 


### PR DESCRIPTION
## Describe your changes

- I added functionality for changing the statuses of related orders.

## Issue ticket code (and/or) and link

- [SCRUM-153](https://codecraftersintership.atlassian.net/browse/SCRUM-153)

### **General**

- [x] types for input and output params
- [x] no `any`, should be also added to eslint rules
- [x] try/catch for any async function
- [x] no **magic** [numbers](/7d77574ee4bc4e339a68066762e887cb)
- [x] compare only with constants not with strings (instead of user === ‘admin’, better user === roles.admin)
- [x] no ternary operator inside ternary operator (bad example: question ? first: second ? third: fourth)
- [x] avoid similar types with duplicating by generics
- [x] no **console.log** in pr
- [x] .env file should be in .gitignore
- [x] delete commented code if it's not part of documentation
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file
- [x] **constants** and **function** names should be lowercase.
- [x] no dates format in the code (like "dd/MM/yyyy”), move it in global constant variable
- [x] import rules. imports should come in a specific order: node modules, absolute path, relative path
- [x] strings should be in the constant variable. Example: instead of ‘15 3 \* \* _’, const EACH_DAY_15h_15min = ‘15 3 _ \* \*’

### Backend

- [x] swagger for each endpoint. add in the documentation, different types of responses.
      on a successful response (2xx), on unsuccessful response (4xx, 5xx)
- [x] less requests to db, all data should be taken with one query
- [x] **public** in method use only is use function externally
- [x] use ConfigService instead of **process.env**
- [ ] use @`@index` decorator for frequently requested data
- [x] use transactions if there is a call chain that mutates data in different tables
- [ ] add a set of rules for [nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments
- [x] use [REST API Naming Convention](https://medium.com/@nadinCodeHat/rest-api-naming-conventions-and-best-practices-1c4e781eb6a5) for endpoints

  P.S: more information about RESTful API design by [Microsof](https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design)t

- [ ] use ‘**UUIDs**` for primary key, ** to prevent Enumeration Attacks**
